### PR TITLE
DataGrid improvements and version bump to 3.3.1

### DIFF
--- a/.claude/skills/cronocode-react-box/SKILL.md
+++ b/.claude/skills/cronocode-react-box/SKILL.md
@@ -5,21 +5,12 @@ description: "@cronocode/react-box expert — runtime CSS-in-JS library. Use whe
 
 # @cronocode/react-box AI Skill
 
-You are an expert in the `@cronocode/react-box` library — a React runtime CSS-in-JS library where the `Box` component accepts ~144 CSS props and generates CSS classes at runtime.
+Runtime CSS-in-JS library. `Box` accepts ~144 CSS props → generates CSS classes at runtime. Same values share a class.
 
 ## Installation & Package Management
 
-When the user needs to install or update `@cronocode/react-box`, detect their package manager and use the correct command:
+Detect package manager via lock files: `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `bun.lockb` → bun, else npm.
 
-```bash
-# Detection order: check lock files in project root
-# pnpm-lock.yaml → pnpm
-# yarn.lock     → yarn
-# bun.lockb     → bun
-# package-lock.json or default → npm
-```
-
-**Install commands:**
 | Manager | Install | Update |
 |---|---|---|
 | npm | `npm install @cronocode/react-box` | `npm update @cronocode/react-box` |
@@ -27,72 +18,55 @@ When the user needs to install or update `@cronocode/react-box`, detect their pa
 | pnpm | `pnpm add @cronocode/react-box` | `pnpm update @cronocode/react-box` |
 | bun | `bun add @cronocode/react-box` | `bun update @cronocode/react-box` |
 
-**Check for updates:**
-```bash
-npm view @cronocode/react-box version  # latest published version
-```
-Compare against the installed version in `package.json`. If outdated, suggest updating.
+Check latest: `npm view @cronocode/react-box version`
 
 ## Critical Rules
 
-1. **NEVER use `style={{ }}`** — always use Box props. Missing prop? Create with `Box.extend()`. `style` is **top-level only** — never inside breakpoints (`sm={{ style: ... }}`), pseudo-classes, or theme objects
+1. **NEVER `style={{ }}`** — use Box props. Missing prop? `Box.extend()`. `style` is top-level only — never inside breakpoints/pseudo-classes/theme
 2. **NEVER `<Box tag="...">`** for common elements — use `<Button>`, `<Link>`, `<H1>`, `<P>`, `<Nav>`, etc.
-3. **NEVER `<Box display="flex/grid">`** — use `<Flex>` / `<Grid>` components
-4. **HTML attributes go in `props` prop**: `<Link props={{ href: '/about' }}>` not `<Link href>`
+3. **NEVER `<Box display="flex/grid">`** — use `<Flex>` / `<Grid>`
+4. **HTML attrs in `props`**: `<Link props={{ href: '/about' }}>` not `<Link href>`
 
 ## Numeric Value Formatters
 
-| Prop Category | Divider | Example | CSS Output |
-|---|---|---|---|
-| Spacing (`p`, `m`, `gap`, `px`, `py`, etc.) | 4 | `p={4}` | 1rem (16px) |
-| Font size (`fontSize`) | **16** | `fontSize={14}` | 0.875rem (14px) |
-| Width/Height (numeric) | 4 | `width={20}` / `height={10}` | 5rem (80px) / 2.5rem (40px) |
-| Min/Max sizing (numeric) | 4 | `maxWidth={300}` | 75rem (1200px) |
-| Border width (`b`, `bx`, `by`, etc.) | none | `b={1}` | 1px |
-| Border radius / lineHeight | none | `borderRadius={8}` | 8px |
+| Category | Divider | Example → CSS |
+|---|---|---|
+| Spacing (`p`,`m`,`gap`,`px`,`py`…) | 4 | `p={4}` → 1rem (16px) |
+| fontSize | **16** | `fontSize={14}` → 0.875rem (14px) |
+| width/height/min/max (numeric) | 4 | `width={20}` → 5rem (80px) |
+| Border (`b`,`bx`,`by`…) | px | `b={1}` → 1px |
+| borderRadius / lineHeight | px | `borderRadius={8}` → 8px |
 
 ## Component Shortcuts
 
-| Instead of... | Use... | Import from |
+| Instead of… | Use | Import |
 |---|---|---|
-| `<Box display="flex">` | `<Flex>` | `@cronocode/react-box/components/flex` |
-| `<Box display="grid">` | `<Grid>` | `@cronocode/react-box/components/grid` |
-| `<Box tag="button">` | `<Button>` | `@cronocode/react-box/components/button` |
-| `<Box tag="input">` | `<Textbox>` | `@cronocode/react-box/components/textbox` |
-| `<Box tag="textarea">` | `<Textarea>` | `@cronocode/react-box/components/textarea` |
-| `<Box tag="a/img/label">` | `<Link>/<Img>/<Label>` | `@cronocode/react-box/components/semantics` |
-| `<Box tag="h1-h6/p/span">` | `<H1>..<H6>/<P>/<Span>` | `@cronocode/react-box/components/semantics` |
-| `<Box tag="nav/header/footer/main">` | `<Nav>/<Header>/<Footer>/<Main>` | `@cronocode/react-box/components/semantics` |
-| `<Box tag="section/article/aside">` | `<Section>/<Article>/<Aside>` | `@cronocode/react-box/components/semantics` |
+| `<Box display="flex/grid">` | `<Flex>`/`<Grid>` | `components/flex`, `components/grid` |
+| `<Box tag="button/input/textarea">` | `<Button>`/`<Textbox>`/`<Textarea>` | `components/button`, `components/textbox`, `components/textarea` |
+| `<Box tag="a/img/label">` | `<Link>`/`<Img>`/`<Label>` | `components/semantics` |
+| `<Box tag="h1..h6/p/span">` | `<H1>..<H6>`/`<P>`/`<Span>` | `components/semantics` |
+| `<Box tag="nav/header/footer/main">` | `<Nav>`/`<Header>`/`<Footer>`/`<Main>` | `components/semantics` |
+| `<Box tag="section/article/aside">` | `<Section>`/`<Article>`/`<Aside>` | `components/semantics` |
 
-Semantics also export: `Mark`, `Figure`, `Figcaption`, `Details`, `Summary`, `Menu`, `Time`.
+Also: `Mark`, `Figure`, `Figcaption`, `Details`, `Summary`, `Menu`, `Time`. All from `@cronocode/react-box/components/...`.
 
-## Prop Reference
+## Props
 
-### Spacing
-`p`/`px`/`py`/`pt`/`pr`/`pb`/`pl` (padding), `m`/`mx`/`my`/`mt`/`mr`/`mb`/`ml` (margin), `gap`
-
-### Layout
-`display`, `d` (flex-direction), `wrap`, `ai` (align-items), `jc` (justify-content), `flex`/`grow`/`shrink`
-
-### Sizing
-`width`/`height` — number (÷4 = rem, NOT pixels), `'auto'`, `'fit'` (100%), `'fit-screen'` (100vw/vh), fractions (`'1/2'`, `'1/3'`, `'2/3'`), percentages (`'33%'`).
-`minWidth`/`maxWidth`/`minHeight`/`maxHeight` — same divider 4. All sizing/spacing/positioning accept percentages: `p="5%"`, `top="10%"`.
-
-### Visual
-Colors: `bgColor`/`color`/`borderColor` — Tailwind palette `'gray-50'`..'gray-900'`, red/orange/yellow/green/teal/blue/indigo/purple/pink/violet, `'white'`/`'black'`/`'transparent'`/`'currentColor'`.
-Borders: `b`/`bx`/`by`/`bt`/`br`/`bb`/`bl` (direct px), `borderRadius` (direct px), `borderStyle`.
-Typography: `fontSize` (divider 16), `fontWeight`, `lineHeight` (direct px), `textAlign`/`textDecoration`/`textTransform`/`whiteSpace`/`textOverflow`.
-Position: `position`, `top`/`right`/`bottom`/`left`/`inset`, `zIndex`.
-Effects: `shadow` (`'small'`/`'medium'`/`'large'`/`'xl'`/`'none'`), `opacity`, `cursor`, `pointerEvents`, `transition`, `transform`, `userSelect`, `overflow`.
+**Spacing**: `p`/`px`/`py`/`pt`/`pr`/`pb`/`pl`, `m`/`mx`/`my`/`mt`/`mr`/`mb`/`ml`, `gap`
+**Layout**: `display`, `d` (flex-direction), `wrap`, `ai` (align-items), `jc` (justify-content), `flex`/`grow`/`shrink`
+**Sizing**: `width`/`height` — number (÷4=rem), `'auto'`, `'fit'` (100%), `'fit-screen'` (100vw/vh), fractions (`'1/2'`…), `'33%'`. `minWidth`/`maxWidth`/`minHeight`/`maxHeight` same. All accept `"5%"`.
+**Colors**: `bgColor`/`color`/`borderColor` — Tailwind palette `'gray-50'`..`'gray-900'`, red/orange/yellow/green/teal/blue/indigo/purple/pink/violet, `'white'`/`'black'`/`'transparent'`/`'currentColor'`
+**Borders**: `b`/`bx`/`by`/`bt`/`br`/`bb`/`bl` (px), `borderRadius` (px), `borderStyle`
+**Text**: `fontSize` (÷16), `fontWeight`, `lineHeight` (px), `textAlign`/`textDecoration`/`textTransform`/`whiteSpace`/`textOverflow`, `textWrap`
+**Position**: `position`, `top`/`right`/`bottom`/`left`/`inset`, `zIndex`
+**Effects**: `shadow` (`'small'`/`'medium'`/`'large'`/`'xl'`/`'none'`), `opacity`, `cursor`, `pointerEvents`, `transition`, `transform`, `userSelect`, `overflow`
 
 ## Pseudo-Classes & Breakpoints
 
 ```tsx
-// Pseudo-classes: hover, focus, active, disabled, checked, indeterminate, required, selected,
-//   focusWithin, focusVisible, first, last, even, odd, empty
 <Box bgColor="blue-500" hover={{ bgColor: 'blue-600' }} disabled={{ opacity: 0.5 }} />
-
+// Pseudo: hover, focus, active, disabled, checked, indeterminate, required, selected,
+//   focusWithin, focusVisible, first, last, even, odd, empty
 // Responsive (mobile-first): sm(640) md(768) lg(1024) xl(1280) xxl(1536)
 <Box p={2} md={{ p: 4, hover: { bgColor: 'gray-200' } }} />
 ```
@@ -100,157 +74,118 @@ Effects: `shadow` (`'small'`/`'medium'`/`'large'`/`'xl'`/`'none'`), `opacity`, `
 ## Theme System
 
 ```tsx
-<Box.Theme>                                {/* auto-detect via prefers-color-scheme */}
-<Box.Theme theme="dark">                   {/* explicit, ignores system pref */}
-<Box.Theme use="global">                   {/* applies class + data-theme to <html> */}
-<Box.Theme storageKey="app-theme">         {/* persists user choice to localStorage */}
-<Box.Theme theme="high-contrast">          {/* supports any custom theme name */}
-
-// Hook: const [theme, setTheme] = Box.useTheme(); (within Box.Theme)
-setTheme('dark');   // set theme (persists if storageKey provided)
-setTheme(null);     // reset to system auto-detection, clears localStorage
-
-// Theme-aware styles — nests with pseudo-classes and breakpoints
+<Box.Theme>                            {/* auto-detect system */}
+<Box.Theme theme="dark" use="global">  {/* explicit + applies to <html> */}
+<Box.Theme storageKey="app-theme">     {/* persists to localStorage */}
+// Hook: const [theme, setTheme] = Box.useTheme();
+// setTheme('dark') | setTheme(null) resets to auto
 <Box bgColor="white" theme={{ dark: { bgColor: 'gray-900', hover: { bgColor: 'gray-700' } } }} />
 ```
 
-**Props**: `theme?` (string), `use?` (`'global'`|`'local'`), `storageKey?` (localStorage persistence key).
-**DOM**: Sets `data-theme` attribute + theme class. Cleaned up on unmount (global mode).
+**Props**: `theme?` (string), `use?` (`'global'`|`'local'`), `storageKey?`. Sets `data-theme` attr + class.
 
 ## Component System
 
 ```tsx
-// Use component + variant for registered styles
-<Box component="card" variant="bordered">
-  <Box component="card.header">Title</Box>
-</Box>
+<Box component="card" variant="bordered"><Box component="card.header">Title</Box></Box>
 
-// Define custom components
-Box.components({
+export const components = Box.components({
   card: {
     styles: { display: 'flex', d: 'column', p: 4, bgColor: 'white', borderRadius: 8, shadow: 'medium' },
     variants: { bordered: { b: 1, borderColor: 'gray-200', shadow: 'none' } },
     children: { header: { styles: { fontSize: 18, fontWeight: 600 } } },
   },
+  subgrid: { extends: 'datagrid', styles: { b: 0, shadow: 'none' } }
 });
 
-// Inheritance
-Box.components({ subgrid: { extends: 'datagrid', styles: { b: 0, shadow: 'none' } } });
 ```
 
 ## Extension System
 
 ```tsx
 export const { extendedProps, extendedPropTypes } = Box.extend(
-  { 'brand-primary': '#ff6600' },             // CSS variables
-  { aspectRatio: [{ values: ['16/9'] as const, styleName: 'aspect-ratio', valueFormat: (v) => v }] }, // New props
-  { bgColor: [{ values: ['brand-primary'] as const, styleName: 'background-color',                    // Extend existing
+  { 'brand-primary': '#ff6600' },                                                          // CSS variables
+  { aspectRatio: [{ values: ['16/9'] as const, styleName: 'aspect-ratio', valueFormat: (v) => v }] },  // New props
+  { bgColor: [{ values: ['brand-primary'] as const, styleName: 'background-color',         // Extend existing
     valueFormat: (v, getVar) => getVar(v) }] },
 );
-
-// TypeScript augmentation (types.d.ts)
-declare module '@cronocode/react-box/types' {
-  namespace Augmented {
-    interface BoxProps extends ExtractBoxStyles<typeof extendedProps> {}
-    interface BoxPropTypes extends ExtractBoxStyles<typeof extendedPropTypes> {}
-    interface ComponentsTypes extends ExtractComponentsAndVariants<typeof components> {}
-  }
-}
+// TypeScript: declare module '@cronocode/react-box/types' { namespace Augmented {
+//   interface BoxProps extends ExtractBoxStyles<typeof extendedProps> {}
+//   interface BoxPropTypes extends ExtractBoxStyles<typeof extendedPropTypes> {}
+//   interface ComponentsTypes extends ExtractComponentsAndVariants<typeof components> {} }}
 ```
 
-## Dropdown Component
+## Dropdown
 
 ```tsx
 import Dropdown from '@cronocode/react-box/components/dropdown';
-
-// Single selection
 <Dropdown<string> defaultValue="a" onChange={(value, values) => {}}>
   <Dropdown.Unselect>Pick...</Dropdown.Unselect>
   <Dropdown.Item value="a">Alpha</Dropdown.Item>
-  <Dropdown.Item value="b">Beta</Dropdown.Item>
 </Dropdown>
-
-// Multiple + search + checkboxes + custom display
-<Dropdown<string> multiple showCheckbox isSearchable searchPlaceholder="Search...">
-  <Dropdown.SelectAll>Select all</Dropdown.SelectAll>
-  <Dropdown.EmptyItem>No results</Dropdown.EmptyItem>
-  <Dropdown.Display>{(values) => `${values.length} selected`}</Dropdown.Display>
-  <Dropdown.Item value="a">Alpha</Dropdown.Item>
-</Dropdown>
+// Multiple: <Dropdown multiple showCheckbox isSearchable searchPlaceholder="Search...">
+//   <Dropdown.SelectAll>All</Dropdown.SelectAll> <Dropdown.EmptyItem>No results</Dropdown.EmptyItem>
+//   <Dropdown.Display>{(values) => `${values.length} selected`}</Dropdown.Display>
 ```
 
-**Props**: `value`/`defaultValue`, `multiple`, `isSearchable`, `searchPlaceholder`, `hideIcon`, `showCheckbox`, `name` (form), `onChange`, `itemsProps` (BoxStyleProps for items container), `iconProps` (BoxStyleProps for icon), `variant` (propagates to all children). Also accepts all BoxProps.
+**Props**: `value`/`defaultValue`, `multiple`, `isSearchable`, `searchPlaceholder`, `hideIcon`, `showCheckbox`, `name`, `onChange`, `itemsProps`, `iconProps`, `variant` (propagates to children). All BoxProps.
+**Sub-components**: `Item<T>` (requires `value`), `Unselect`, `SelectAll`, `EmptyItem`, `Display` (static or `(values, isOpen) => ReactNode`).
+**Style tree**: `dropdown` > `items`, `item` (variants: compact, multiple), `unselect`, `selectAll`, `emptyItem`, `icon`.
 
-**Sub-components** (all accept BoxProps): `Dropdown.Item<TVal>` (requires `value`), `Dropdown.Unselect`, `Dropdown.SelectAll`, `Dropdown.EmptyItem`, `Dropdown.Display` (static or `(values, isOpen) => ReactNode`).
+## Select
 
-**Style tree**: `dropdown`, `dropdown.items`, `dropdown.item` (variants: compact, multiple), `dropdown.unselect`, `dropdown.selectAll`, `dropdown.emptyItem`, `dropdown.icon`. Custom variants propagate to all children.
-
-## Select Component
-
-Data-driven dropdown — pass `data` + `def` instead of composing children. Wraps Dropdown, shares `dropdown.*` style tree.
+Data-driven dropdown — `data` + `def` instead of children. Shares `dropdown.*` style tree.
 
 ```tsx
 import Select from '@cronocode/react-box/components/select';
-
 <Select<User, number> data={users} def={{ valueKey: 'id', displayKey: 'name', placeholder: 'Pick...' }}
   value={selected} onChange={(value) => setSelected(value!)} />
-
-// Multiple + search + custom display
-<Select<User, number> data={users} multiple showCheckbox isSearchable searchPlaceholder="Search..."
-  def={{
-    valueKey: 'id', displayKey: 'name', selectAllText: 'Select all', emptyText: 'No results',
-    display: (user) => `${user.name} — ${user.role}`,
-    selectedDisplay: (rows) => `${rows.length} selected`,
-  }} />
 ```
 
-**SelectDef**: `valueKey` (required — field as value), `displayKey` (field to display, defaults to valueKey), `display` (`(row) => ReactNode` per item), `selectedDisplay` (`(rows, isOpen) => ReactNode` for trigger), `placeholder`, `selectAllText`, `emptyText`.
+**SelectDef**: `valueKey` (required), `displayKey`, `display` (`(row) => ReactNode`), `selectedDisplay` (`(rows, isOpen) => ReactNode`), `placeholder`, `selectAllText`, `emptyText`.
+Also: `data`, `value`/`defaultValue`, `multiple`, `isSearchable`, `searchPlaceholder`, `showCheckbox`, `hideIcon`, `name`, `onChange`, `itemsProps`, `iconProps`, `variant`, BoxProps.
 
-Also accepts: `data`, `value`/`defaultValue`, `multiple`, `isSearchable`, `searchPlaceholder`, `showCheckbox`, `hideIcon`, `name`, `onChange`, `itemsProps`, `iconProps`, `variant`, and all BoxProps. Same styling/variants as Dropdown.
-
-## DataGrid Component
+## DataGrid
 
 ```tsx
 import DataGrid from '@cronocode/react-box/components/dataGrid';
-
 <DataGrid data={users} def={{
   rowKey: 'id', topBar: true, bottomBar: true, globalFilter: true,
   rowSelection: { pinned: true }, showRowNumber: { pinned: true },
-  rowHeight: 40, visibleRowsCount: 15, // 'all' disables virtualization
+  rowHeight: 40, visibleRowsCount: 15,
   columns: [
     { key: 'name', header: 'Name', filterable: true },
     { key: 'age', header: 'Age', width: 80, align: 'right', filterable: { type: 'number' } },
     { key: 'status', header: 'Status', filterable: { type: 'multiselect' } },
     { key: 'country', header: 'Country', pin: 'RIGHT' },
-    { key: 'actions', header: '', pin: 'RIGHT', width: 80, sortable: false,
+    { key: 'actions', header: '', width: 80, sortable: false, contextMenu: false,
       Cell: ({ cell }) => <Button onClick={() => edit(cell.row.data)}>Edit</Button> },
   ],
-  rowDetail: { content: (row) => <Details row={row} />, height: 'auto', expandOnRowClick: true },
+  rowDetail: { content: (row) => <Details row={row} />, expandOnRowClick: true, expandColumnHeader: 'Details' },
+  contextMenu: { sort: true, pin: true, group: false }, resizerStyle: 'hover',
 }} onSelectionChange={(e) => console.log(e.selectedRowKeys)} />
 ```
 
-**DataGridProps**: `data` (TRow[]), `def` (GridDefinition), `component` (style tree, default `'datagrid'`), `loading`, `filters` (predicate array), `page`/`onPageChange`, `onSortChange` (columnKey, `'ASC'`/`'DESC'`/undefined), `onServerStateChange` (`{ page, pageSize, sortColumn, sortDirection, columnFilters, globalFilterValue }`), `onSelectionChange` (`{ action, selectedRowKeys, affectedRowKeys, isAllSelected }`), `expandedRowKeys`/`onExpandedRowKeysChange`, `globalFilterValue`/`onGlobalFilterChange`, `columnFilters`/`onColumnFiltersChange`.
+**DataGridProps**: `data`, `def`, `component` (default `'datagrid'`), `loading`, `filters` (predicate[]), `page`/`onPageChange`, `onSortChange`, `onServerStateChange` (`{ page, pageSize, sortColumn, sortDirection, columnFilters, globalFilterValue }`), `onSelectionChange` (`{ action, selectedRowKeys, affectedRowKeys, isAllSelected }`), `expandedRowKeys`/`onExpandedRowKeysChange`, `globalFilterValue`/`onGlobalFilterChange`, `columnFilters`/`onColumnFiltersChange`.
 
-**GridDefinition**: `columns` (required), `rowKey` (keyof TRow or fn), `rowHeight` (px, default 48), `visibleRowsCount` (number or `'all'`, default 10), `showRowNumber` (bool or `{ pinned?, width? }`), `rowSelection` (bool or `{ pinned? }`), `rowDetail` (`{ content, height?, expandOnRowClick?, pinned? }`), `pagination` (`{ totalCount, pageSize? }` — enables server-side, bypasses client filtering), `topBar`/`bottomBar` (bool), `title`/`topBarContent` (ReactNode), `globalFilter` (bool), `globalFilterKeys` (keyof TRow[]), `sortable`/`resizable` (bool, default true), `noDataComponent`.
+**GridDefinition**: `columns` (required), `rowKey`, `rowHeight` (px, default 48), `visibleRowsCount` (number/`'all'`), `showRowNumber` (bool/`{ pinned?, width? }`), `rowSelection` (bool/`{ pinned? }`), `rowDetail` (`{ content, height?, expandOnRowClick?, pinned?, expandColumnWidth?, expandColumnHeader? }`), `pagination` (`{ totalCount, pageSize? }`), `topBar`/`bottomBar`, `title`/`topBarContent`, `globalFilter`, `globalFilterKeys`, `sortable`/`resizable` (default true), `contextMenu` (bool/`{ sort?, pin?, group? }`, default true), `resizerStyle` (`'visible'`/`'hover'`/`'hidden'`), `noDataComponent`.
 
-**ColumnType**: `key`, `header`, `width` (px, default 200), `align` (`'left'`/`'right'`/`'center'`), `pin` (`'LEFT'`/`'RIGHT'`), `columns` (nested for grouped headers), `Cell` (`({ cell }) => ReactNode`, cell has `value`, `row`, `column`, `grid`), `sortable`/`resizable` (override grid), `flexible` (default true), `filterable` (`true` = text, `{ type: 'number', min?, max? }`, `{ type: 'multiselect', options? }`).
+**ColumnType**: `key`, `header`, `width` (px, default 200), `align`, `pin` (`'LEFT'`/`'RIGHT'`), `columns` (grouped headers), `Cell` (`({ cell }) => ReactNode`), `sortable`/`resizable` (override grid), `flexible`, `filterable` (`true`=text, `{ type: 'number' }`, `{ type: 'multiselect' }`), `contextMenu` (override grid).
 
-**Server-side pagination**: `def={{ pagination: { totalCount, pageSize }, bottomBar: true }}` + `page={page}` + `onServerStateChange={(state) => refetch(state)}`.
+**Server-side**: `def={{ pagination: { totalCount }, bottomBar: true }}` + `page={page}` + `onServerStateChange={fetchData}`.
 
-**Style tree** (all customizable via `Box.components()`, use `extends: 'datagrid'` for variant grids):
-`datagrid` > `content`, `topBar` > (`globalFilter` > `stats`, `columnGroups` > `icon` | `separator` | `item` > `icon`, `columnVisibility` > `badge`), `filter` > `cell` > `input`, `header` > `cell` > (`contextMenu` > `icon` | `tooltip` > `item` > `icon` | `separator`, `resizer`), `body` > (`cell` > `text` | `rowDetail`, `row`, `groupRow` > `expandButton`, `detailRow`, `empty`), `emptyColumns`, `bottomBar` > (`info`, `clearFilters`, `pagination` > `button` | `info`).
-Cell variants: `isPinned`, `isFirstLeftPinned`, `isLastLeftPinned`, `isFirstRightPinned`, `isLastRightPinned`, `isRowNumber`, `isRowSelection`, `isRowSelected`, `isSortable`, `isFirstLeaf`, `isLastLeaf`, `isEmptyCell`.
+**Style tree**: `datagrid` > `content`, `topBar` > (`globalFilter` > `stats`, `columnGroups` > `icon`|`separator`|`item` > `icon`, `columnVisibility` > `badge`), `filter` > `cell` > `input`, `header` > `cell` > (`contextMenu` > `icon`|`tooltip` > `item` > `icon`|`separator`, `resizer`), `body` > (`cell` > `text`|`rowDetail`, `row`, `groupRow` > `expandButton`, `detailRow`, `empty`), `emptyColumns`, `bottomBar` > (`info`, `clearFilters`, `pagination` > `button`|`info`).
 
 ## Common Patterns
 
 ```tsx
 <Flex d="column" gap={4} ai="center" jc="between">{children}</Flex>
-<Flex d="column" gap={2} md={{ d: 'row', gap: 4 }}>{children}</Flex>  // responsive stack
+<Flex d="column" gap={2} md={{ d: 'row', gap: 4 }}>{children}</Flex>
 <Grid gridCols={3} gap={4}>{items}</Grid>
-<Box p={4} bgColor="white" borderRadius={8} shadow="medium" />        // card
-<Box overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap" />  // truncated text
+<Box p={4} bgColor="white" borderRadius={8} shadow="medium" />
+<Box overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap" />
 ```
 
 **Group hover**: `<Box hoverGroup={{ 'parent-class': { opacity: 1 } }}>`
 **SSR**: `import { getStyles, resetStyles } from '@cronocode/react-box/ssg'`
-**Portals**: Tooltip component for escaping `overflow: hidden` (renders into `#crono-box` container)
+**Portals**: Tooltip for escaping `overflow: hidden` (renders into `#crono-box`)

--- a/marketplace-skill/skills/cronocode-react-box/SKILL.md
+++ b/marketplace-skill/skills/cronocode-react-box/SKILL.md
@@ -5,21 +5,12 @@ description: "@cronocode/react-box expert — runtime CSS-in-JS library. Use whe
 
 # @cronocode/react-box AI Skill
 
-You are an expert in the `@cronocode/react-box` library — a React runtime CSS-in-JS library where the `Box` component accepts ~144 CSS props and generates CSS classes at runtime.
+Runtime CSS-in-JS library. `Box` accepts ~144 CSS props → generates CSS classes at runtime. Same values share a class.
 
 ## Installation & Package Management
 
-When the user needs to install or update `@cronocode/react-box`, detect their package manager and use the correct command:
+Detect package manager via lock files: `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `bun.lockb` → bun, else npm.
 
-```bash
-# Detection order: check lock files in project root
-# pnpm-lock.yaml → pnpm
-# yarn.lock     → yarn
-# bun.lockb     → bun
-# package-lock.json or default → npm
-```
-
-**Install commands:**
 | Manager | Install | Update |
 |---|---|---|
 | npm | `npm install @cronocode/react-box` | `npm update @cronocode/react-box` |
@@ -27,72 +18,55 @@ When the user needs to install or update `@cronocode/react-box`, detect their pa
 | pnpm | `pnpm add @cronocode/react-box` | `pnpm update @cronocode/react-box` |
 | bun | `bun add @cronocode/react-box` | `bun update @cronocode/react-box` |
 
-**Check for updates:**
-```bash
-npm view @cronocode/react-box version  # latest published version
-```
-Compare against the installed version in `package.json`. If outdated, suggest updating.
+Check latest: `npm view @cronocode/react-box version`
 
 ## Critical Rules
 
-1. **NEVER use `style={{ }}`** — always use Box props. Missing prop? Create with `Box.extend()`. `style` is **top-level only** — never inside breakpoints (`sm={{ style: ... }}`), pseudo-classes, or theme objects
+1. **NEVER `style={{ }}`** — use Box props. Missing prop? `Box.extend()`. `style` is top-level only — never inside breakpoints/pseudo-classes/theme
 2. **NEVER `<Box tag="...">`** for common elements — use `<Button>`, `<Link>`, `<H1>`, `<P>`, `<Nav>`, etc.
-3. **NEVER `<Box display="flex/grid">`** — use `<Flex>` / `<Grid>` components
-4. **HTML attributes go in `props` prop**: `<Link props={{ href: '/about' }}>` not `<Link href>`
+3. **NEVER `<Box display="flex/grid">`** — use `<Flex>` / `<Grid>`
+4. **HTML attrs in `props`**: `<Link props={{ href: '/about' }}>` not `<Link href>`
 
 ## Numeric Value Formatters
 
-| Prop Category | Divider | Example | CSS Output |
-|---|---|---|---|
-| Spacing (`p`, `m`, `gap`, `px`, `py`, etc.) | 4 | `p={4}` | 1rem (16px) |
-| Font size (`fontSize`) | **16** | `fontSize={14}` | 0.875rem (14px) |
-| Width/Height (numeric) | 4 | `width={20}` / `height={10}` | 5rem (80px) / 2.5rem (40px) |
-| Min/Max sizing (numeric) | 4 | `maxWidth={300}` | 75rem (1200px) |
-| Border width (`b`, `bx`, `by`, etc.) | none | `b={1}` | 1px |
-| Border radius / lineHeight | none | `borderRadius={8}` | 8px |
+| Category | Divider | Example → CSS |
+|---|---|---|
+| Spacing (`p`,`m`,`gap`,`px`,`py`…) | 4 | `p={4}` → 1rem (16px) |
+| fontSize | **16** | `fontSize={14}` → 0.875rem (14px) |
+| width/height/min/max (numeric) | 4 | `width={20}` → 5rem (80px) |
+| Border (`b`,`bx`,`by`…) | px | `b={1}` → 1px |
+| borderRadius / lineHeight | px | `borderRadius={8}` → 8px |
 
 ## Component Shortcuts
 
-| Instead of... | Use... | Import from |
+| Instead of… | Use | Import |
 |---|---|---|
-| `<Box display="flex">` | `<Flex>` | `@cronocode/react-box/components/flex` |
-| `<Box display="grid">` | `<Grid>` | `@cronocode/react-box/components/grid` |
-| `<Box tag="button">` | `<Button>` | `@cronocode/react-box/components/button` |
-| `<Box tag="input">` | `<Textbox>` | `@cronocode/react-box/components/textbox` |
-| `<Box tag="textarea">` | `<Textarea>` | `@cronocode/react-box/components/textarea` |
-| `<Box tag="a/img/label">` | `<Link>/<Img>/<Label>` | `@cronocode/react-box/components/semantics` |
-| `<Box tag="h1-h6/p/span">` | `<H1>..<H6>/<P>/<Span>` | `@cronocode/react-box/components/semantics` |
-| `<Box tag="nav/header/footer/main">` | `<Nav>/<Header>/<Footer>/<Main>` | `@cronocode/react-box/components/semantics` |
-| `<Box tag="section/article/aside">` | `<Section>/<Article>/<Aside>` | `@cronocode/react-box/components/semantics` |
+| `<Box display="flex/grid">` | `<Flex>`/`<Grid>` | `components/flex`, `components/grid` |
+| `<Box tag="button/input/textarea">` | `<Button>`/`<Textbox>`/`<Textarea>` | `components/button`, `components/textbox`, `components/textarea` |
+| `<Box tag="a/img/label">` | `<Link>`/`<Img>`/`<Label>` | `components/semantics` |
+| `<Box tag="h1..h6/p/span">` | `<H1>..<H6>`/`<P>`/`<Span>` | `components/semantics` |
+| `<Box tag="nav/header/footer/main">` | `<Nav>`/`<Header>`/`<Footer>`/`<Main>` | `components/semantics` |
+| `<Box tag="section/article/aside">` | `<Section>`/`<Article>`/`<Aside>` | `components/semantics` |
 
-Semantics also export: `Mark`, `Figure`, `Figcaption`, `Details`, `Summary`, `Menu`, `Time`.
+Also: `Mark`, `Figure`, `Figcaption`, `Details`, `Summary`, `Menu`, `Time`. All from `@cronocode/react-box/components/...`.
 
-## Prop Reference
+## Props
 
-### Spacing
-`p`/`px`/`py`/`pt`/`pr`/`pb`/`pl` (padding), `m`/`mx`/`my`/`mt`/`mr`/`mb`/`ml` (margin), `gap`
-
-### Layout
-`display`, `d` (flex-direction), `wrap`, `ai` (align-items), `jc` (justify-content), `flex`/`grow`/`shrink`
-
-### Sizing
-`width`/`height` — number (÷4 = rem, NOT pixels), `'auto'`, `'fit'` (100%), `'fit-screen'` (100vw/vh), fractions (`'1/2'`, `'1/3'`, `'2/3'`), percentages (`'33%'`).
-`minWidth`/`maxWidth`/`minHeight`/`maxHeight` — same divider 4. All sizing/spacing/positioning accept percentages: `p="5%"`, `top="10%"`.
-
-### Visual
-Colors: `bgColor`/`color`/`borderColor` — Tailwind palette `'gray-50'`..'gray-900'`, red/orange/yellow/green/teal/blue/indigo/purple/pink/violet, `'white'`/`'black'`/`'transparent'`/`'currentColor'`.
-Borders: `b`/`bx`/`by`/`bt`/`br`/`bb`/`bl` (direct px), `borderRadius` (direct px), `borderStyle`.
-Typography: `fontSize` (divider 16), `fontWeight`, `lineHeight` (direct px), `textAlign`/`textDecoration`/`textTransform`/`whiteSpace`/`textOverflow`.
-Position: `position`, `top`/`right`/`bottom`/`left`/`inset`, `zIndex`.
-Effects: `shadow` (`'small'`/`'medium'`/`'large'`/`'xl'`/`'none'`), `opacity`, `cursor`, `pointerEvents`, `transition`, `transform`, `userSelect`, `overflow`.
+**Spacing**: `p`/`px`/`py`/`pt`/`pr`/`pb`/`pl`, `m`/`mx`/`my`/`mt`/`mr`/`mb`/`ml`, `gap`
+**Layout**: `display`, `d` (flex-direction), `wrap`, `ai` (align-items), `jc` (justify-content), `flex`/`grow`/`shrink`
+**Sizing**: `width`/`height` — number (÷4=rem), `'auto'`, `'fit'` (100%), `'fit-screen'` (100vw/vh), fractions (`'1/2'`…), `'33%'`. `minWidth`/`maxWidth`/`minHeight`/`maxHeight` same. All accept `"5%"`.
+**Colors**: `bgColor`/`color`/`borderColor` — Tailwind palette `'gray-50'`..`'gray-900'`, red/orange/yellow/green/teal/blue/indigo/purple/pink/violet, `'white'`/`'black'`/`'transparent'`/`'currentColor'`
+**Borders**: `b`/`bx`/`by`/`bt`/`br`/`bb`/`bl` (px), `borderRadius` (px), `borderStyle`
+**Text**: `fontSize` (÷16), `fontWeight`, `lineHeight` (px), `textAlign`/`textDecoration`/`textTransform`/`whiteSpace`/`textOverflow`, `textWrap`
+**Position**: `position`, `top`/`right`/`bottom`/`left`/`inset`, `zIndex`
+**Effects**: `shadow` (`'small'`/`'medium'`/`'large'`/`'xl'`/`'none'`), `opacity`, `cursor`, `pointerEvents`, `transition`, `transform`, `userSelect`, `overflow`
 
 ## Pseudo-Classes & Breakpoints
 
 ```tsx
-// Pseudo-classes: hover, focus, active, disabled, checked, indeterminate, required, selected,
-//   focusWithin, focusVisible, first, last, even, odd, empty
 <Box bgColor="blue-500" hover={{ bgColor: 'blue-600' }} disabled={{ opacity: 0.5 }} />
-
+// Pseudo: hover, focus, active, disabled, checked, indeterminate, required, selected,
+//   focusWithin, focusVisible, first, last, even, odd, empty
 // Responsive (mobile-first): sm(640) md(768) lg(1024) xl(1280) xxl(1536)
 <Box p={2} md={{ p: 4, hover: { bgColor: 'gray-200' } }} />
 ```
@@ -100,157 +74,118 @@ Effects: `shadow` (`'small'`/`'medium'`/`'large'`/`'xl'`/`'none'`), `opacity`, `
 ## Theme System
 
 ```tsx
-<Box.Theme>                                {/* auto-detect via prefers-color-scheme */}
-<Box.Theme theme="dark">                   {/* explicit, ignores system pref */}
-<Box.Theme use="global">                   {/* applies class + data-theme to <html> */}
-<Box.Theme storageKey="app-theme">         {/* persists user choice to localStorage */}
-<Box.Theme theme="high-contrast">          {/* supports any custom theme name */}
-
-// Hook: const [theme, setTheme] = Box.useTheme(); (within Box.Theme)
-setTheme('dark');   // set theme (persists if storageKey provided)
-setTheme(null);     // reset to system auto-detection, clears localStorage
-
-// Theme-aware styles — nests with pseudo-classes and breakpoints
+<Box.Theme>                            {/* auto-detect system */}
+<Box.Theme theme="dark" use="global">  {/* explicit + applies to <html> */}
+<Box.Theme storageKey="app-theme">     {/* persists to localStorage */}
+// Hook: const [theme, setTheme] = Box.useTheme();
+// setTheme('dark') | setTheme(null) resets to auto
 <Box bgColor="white" theme={{ dark: { bgColor: 'gray-900', hover: { bgColor: 'gray-700' } } }} />
 ```
 
-**Props**: `theme?` (string), `use?` (`'global'`|`'local'`), `storageKey?` (localStorage persistence key).
-**DOM**: Sets `data-theme` attribute + theme class. Cleaned up on unmount (global mode).
+**Props**: `theme?` (string), `use?` (`'global'`|`'local'`), `storageKey?`. Sets `data-theme` attr + class.
 
 ## Component System
 
 ```tsx
-// Use component + variant for registered styles
-<Box component="card" variant="bordered">
-  <Box component="card.header">Title</Box>
-</Box>
+<Box component="card" variant="bordered"><Box component="card.header">Title</Box></Box>
 
-// Define custom components
-Box.components({
+export const components = Box.components({
   card: {
     styles: { display: 'flex', d: 'column', p: 4, bgColor: 'white', borderRadius: 8, shadow: 'medium' },
     variants: { bordered: { b: 1, borderColor: 'gray-200', shadow: 'none' } },
     children: { header: { styles: { fontSize: 18, fontWeight: 600 } } },
   },
+  subgrid: { extends: 'datagrid', styles: { b: 0, shadow: 'none' } }
 });
 
-// Inheritance
-Box.components({ subgrid: { extends: 'datagrid', styles: { b: 0, shadow: 'none' } } });
 ```
 
 ## Extension System
 
 ```tsx
 export const { extendedProps, extendedPropTypes } = Box.extend(
-  { 'brand-primary': '#ff6600' },             // CSS variables
-  { aspectRatio: [{ values: ['16/9'] as const, styleName: 'aspect-ratio', valueFormat: (v) => v }] }, // New props
-  { bgColor: [{ values: ['brand-primary'] as const, styleName: 'background-color',                    // Extend existing
+  { 'brand-primary': '#ff6600' },                                                          // CSS variables
+  { aspectRatio: [{ values: ['16/9'] as const, styleName: 'aspect-ratio', valueFormat: (v) => v }] },  // New props
+  { bgColor: [{ values: ['brand-primary'] as const, styleName: 'background-color',         // Extend existing
     valueFormat: (v, getVar) => getVar(v) }] },
 );
-
-// TypeScript augmentation (types.d.ts)
-declare module '@cronocode/react-box/types' {
-  namespace Augmented {
-    interface BoxProps extends ExtractBoxStyles<typeof extendedProps> {}
-    interface BoxPropTypes extends ExtractBoxStyles<typeof extendedPropTypes> {}
-    interface ComponentsTypes extends ExtractComponentsAndVariants<typeof components> {}
-  }
-}
+// TypeScript: declare module '@cronocode/react-box/types' { namespace Augmented {
+//   interface BoxProps extends ExtractBoxStyles<typeof extendedProps> {}
+//   interface BoxPropTypes extends ExtractBoxStyles<typeof extendedPropTypes> {}
+//   interface ComponentsTypes extends ExtractComponentsAndVariants<typeof components> {} }}
 ```
 
-## Dropdown Component
+## Dropdown
 
 ```tsx
 import Dropdown from '@cronocode/react-box/components/dropdown';
-
-// Single selection
 <Dropdown<string> defaultValue="a" onChange={(value, values) => {}}>
   <Dropdown.Unselect>Pick...</Dropdown.Unselect>
   <Dropdown.Item value="a">Alpha</Dropdown.Item>
-  <Dropdown.Item value="b">Beta</Dropdown.Item>
 </Dropdown>
-
-// Multiple + search + checkboxes + custom display
-<Dropdown<string> multiple showCheckbox isSearchable searchPlaceholder="Search...">
-  <Dropdown.SelectAll>Select all</Dropdown.SelectAll>
-  <Dropdown.EmptyItem>No results</Dropdown.EmptyItem>
-  <Dropdown.Display>{(values) => `${values.length} selected`}</Dropdown.Display>
-  <Dropdown.Item value="a">Alpha</Dropdown.Item>
-</Dropdown>
+// Multiple: <Dropdown multiple showCheckbox isSearchable searchPlaceholder="Search...">
+//   <Dropdown.SelectAll>All</Dropdown.SelectAll> <Dropdown.EmptyItem>No results</Dropdown.EmptyItem>
+//   <Dropdown.Display>{(values) => `${values.length} selected`}</Dropdown.Display>
 ```
 
-**Props**: `value`/`defaultValue`, `multiple`, `isSearchable`, `searchPlaceholder`, `hideIcon`, `showCheckbox`, `name` (form), `onChange`, `itemsProps` (BoxStyleProps for items container), `iconProps` (BoxStyleProps for icon), `variant` (propagates to all children). Also accepts all BoxProps.
+**Props**: `value`/`defaultValue`, `multiple`, `isSearchable`, `searchPlaceholder`, `hideIcon`, `showCheckbox`, `name`, `onChange`, `itemsProps`, `iconProps`, `variant` (propagates to children). All BoxProps.
+**Sub-components**: `Item<T>` (requires `value`), `Unselect`, `SelectAll`, `EmptyItem`, `Display` (static or `(values, isOpen) => ReactNode`).
+**Style tree**: `dropdown` > `items`, `item` (variants: compact, multiple), `unselect`, `selectAll`, `emptyItem`, `icon`.
 
-**Sub-components** (all accept BoxProps): `Dropdown.Item<TVal>` (requires `value`), `Dropdown.Unselect`, `Dropdown.SelectAll`, `Dropdown.EmptyItem`, `Dropdown.Display` (static or `(values, isOpen) => ReactNode`).
+## Select
 
-**Style tree**: `dropdown`, `dropdown.items`, `dropdown.item` (variants: compact, multiple), `dropdown.unselect`, `dropdown.selectAll`, `dropdown.emptyItem`, `dropdown.icon`. Custom variants propagate to all children.
-
-## Select Component
-
-Data-driven dropdown — pass `data` + `def` instead of composing children. Wraps Dropdown, shares `dropdown.*` style tree.
+Data-driven dropdown — `data` + `def` instead of children. Shares `dropdown.*` style tree.
 
 ```tsx
 import Select from '@cronocode/react-box/components/select';
-
 <Select<User, number> data={users} def={{ valueKey: 'id', displayKey: 'name', placeholder: 'Pick...' }}
   value={selected} onChange={(value) => setSelected(value!)} />
-
-// Multiple + search + custom display
-<Select<User, number> data={users} multiple showCheckbox isSearchable searchPlaceholder="Search..."
-  def={{
-    valueKey: 'id', displayKey: 'name', selectAllText: 'Select all', emptyText: 'No results',
-    display: (user) => `${user.name} — ${user.role}`,
-    selectedDisplay: (rows) => `${rows.length} selected`,
-  }} />
 ```
 
-**SelectDef**: `valueKey` (required — field as value), `displayKey` (field to display, defaults to valueKey), `display` (`(row) => ReactNode` per item), `selectedDisplay` (`(rows, isOpen) => ReactNode` for trigger), `placeholder`, `selectAllText`, `emptyText`.
+**SelectDef**: `valueKey` (required), `displayKey`, `display` (`(row) => ReactNode`), `selectedDisplay` (`(rows, isOpen) => ReactNode`), `placeholder`, `selectAllText`, `emptyText`.
+Also: `data`, `value`/`defaultValue`, `multiple`, `isSearchable`, `searchPlaceholder`, `showCheckbox`, `hideIcon`, `name`, `onChange`, `itemsProps`, `iconProps`, `variant`, BoxProps.
 
-Also accepts: `data`, `value`/`defaultValue`, `multiple`, `isSearchable`, `searchPlaceholder`, `showCheckbox`, `hideIcon`, `name`, `onChange`, `itemsProps`, `iconProps`, `variant`, and all BoxProps. Same styling/variants as Dropdown.
-
-## DataGrid Component
+## DataGrid
 
 ```tsx
 import DataGrid from '@cronocode/react-box/components/dataGrid';
-
 <DataGrid data={users} def={{
   rowKey: 'id', topBar: true, bottomBar: true, globalFilter: true,
   rowSelection: { pinned: true }, showRowNumber: { pinned: true },
-  rowHeight: 40, visibleRowsCount: 15, // 'all' disables virtualization
+  rowHeight: 40, visibleRowsCount: 15,
   columns: [
     { key: 'name', header: 'Name', filterable: true },
     { key: 'age', header: 'Age', width: 80, align: 'right', filterable: { type: 'number' } },
     { key: 'status', header: 'Status', filterable: { type: 'multiselect' } },
     { key: 'country', header: 'Country', pin: 'RIGHT' },
-    { key: 'actions', header: '', pin: 'RIGHT', width: 80, sortable: false,
+    { key: 'actions', header: '', width: 80, sortable: false, contextMenu: false,
       Cell: ({ cell }) => <Button onClick={() => edit(cell.row.data)}>Edit</Button> },
   ],
-  rowDetail: { content: (row) => <Details row={row} />, height: 'auto', expandOnRowClick: true },
+  rowDetail: { content: (row) => <Details row={row} />, expandOnRowClick: true, expandColumnHeader: 'Details' },
+  contextMenu: { sort: true, pin: true, group: false }, resizerStyle: 'hover',
 }} onSelectionChange={(e) => console.log(e.selectedRowKeys)} />
 ```
 
-**DataGridProps**: `data` (TRow[]), `def` (GridDefinition), `component` (style tree, default `'datagrid'`), `loading`, `filters` (predicate array), `page`/`onPageChange`, `onSortChange` (columnKey, `'ASC'`/`'DESC'`/undefined), `onServerStateChange` (`{ page, pageSize, sortColumn, sortDirection, columnFilters, globalFilterValue }`), `onSelectionChange` (`{ action, selectedRowKeys, affectedRowKeys, isAllSelected }`), `expandedRowKeys`/`onExpandedRowKeysChange`, `globalFilterValue`/`onGlobalFilterChange`, `columnFilters`/`onColumnFiltersChange`.
+**DataGridProps**: `data`, `def`, `component` (default `'datagrid'`), `loading`, `filters` (predicate[]), `page`/`onPageChange`, `onSortChange`, `onServerStateChange` (`{ page, pageSize, sortColumn, sortDirection, columnFilters, globalFilterValue }`), `onSelectionChange` (`{ action, selectedRowKeys, affectedRowKeys, isAllSelected }`), `expandedRowKeys`/`onExpandedRowKeysChange`, `globalFilterValue`/`onGlobalFilterChange`, `columnFilters`/`onColumnFiltersChange`.
 
-**GridDefinition**: `columns` (required), `rowKey` (keyof TRow or fn), `rowHeight` (px, default 48), `visibleRowsCount` (number or `'all'`, default 10), `showRowNumber` (bool or `{ pinned?, width? }`), `rowSelection` (bool or `{ pinned? }`), `rowDetail` (`{ content, height?, expandOnRowClick?, pinned? }`), `pagination` (`{ totalCount, pageSize? }` — enables server-side, bypasses client filtering), `topBar`/`bottomBar` (bool), `title`/`topBarContent` (ReactNode), `globalFilter` (bool), `globalFilterKeys` (keyof TRow[]), `sortable`/`resizable` (bool, default true), `noDataComponent`.
+**GridDefinition**: `columns` (required), `rowKey`, `rowHeight` (px, default 48), `visibleRowsCount` (number/`'all'`), `showRowNumber` (bool/`{ pinned?, width? }`), `rowSelection` (bool/`{ pinned? }`), `rowDetail` (`{ content, height?, expandOnRowClick?, pinned?, expandColumnWidth?, expandColumnHeader? }`), `pagination` (`{ totalCount, pageSize? }`), `topBar`/`bottomBar`, `title`/`topBarContent`, `globalFilter`, `globalFilterKeys`, `sortable`/`resizable` (default true), `contextMenu` (bool/`{ sort?, pin?, group? }`, default true), `resizerStyle` (`'visible'`/`'hover'`/`'hidden'`), `noDataComponent`.
 
-**ColumnType**: `key`, `header`, `width` (px, default 200), `align` (`'left'`/`'right'`/`'center'`), `pin` (`'LEFT'`/`'RIGHT'`), `columns` (nested for grouped headers), `Cell` (`({ cell }) => ReactNode`, cell has `value`, `row`, `column`, `grid`), `sortable`/`resizable` (override grid), `flexible` (default true), `filterable` (`true` = text, `{ type: 'number', min?, max? }`, `{ type: 'multiselect', options? }`).
+**ColumnType**: `key`, `header`, `width` (px, default 200), `align`, `pin` (`'LEFT'`/`'RIGHT'`), `columns` (grouped headers), `Cell` (`({ cell }) => ReactNode`), `sortable`/`resizable` (override grid), `flexible`, `filterable` (`true`=text, `{ type: 'number' }`, `{ type: 'multiselect' }`), `contextMenu` (override grid).
 
-**Server-side pagination**: `def={{ pagination: { totalCount, pageSize }, bottomBar: true }}` + `page={page}` + `onServerStateChange={(state) => refetch(state)}`.
+**Server-side**: `def={{ pagination: { totalCount }, bottomBar: true }}` + `page={page}` + `onServerStateChange={fetchData}`.
 
-**Style tree** (all customizable via `Box.components()`, use `extends: 'datagrid'` for variant grids):
-`datagrid` > `content`, `topBar` > (`globalFilter` > `stats`, `columnGroups` > `icon` | `separator` | `item` > `icon`, `columnVisibility` > `badge`), `filter` > `cell` > `input`, `header` > `cell` > (`contextMenu` > `icon` | `tooltip` > `item` > `icon` | `separator`, `resizer`), `body` > (`cell` > `text` | `rowDetail`, `row`, `groupRow` > `expandButton`, `detailRow`, `empty`), `emptyColumns`, `bottomBar` > (`info`, `clearFilters`, `pagination` > `button` | `info`).
-Cell variants: `isPinned`, `isFirstLeftPinned`, `isLastLeftPinned`, `isFirstRightPinned`, `isLastRightPinned`, `isRowNumber`, `isRowSelection`, `isRowSelected`, `isSortable`, `isFirstLeaf`, `isLastLeaf`, `isEmptyCell`.
+**Style tree**: `datagrid` > `content`, `topBar` > (`globalFilter` > `stats`, `columnGroups` > `icon`|`separator`|`item` > `icon`, `columnVisibility` > `badge`), `filter` > `cell` > `input`, `header` > `cell` > (`contextMenu` > `icon`|`tooltip` > `item` > `icon`|`separator`, `resizer`), `body` > (`cell` > `text`|`rowDetail`, `row`, `groupRow` > `expandButton`, `detailRow`, `empty`), `emptyColumns`, `bottomBar` > (`info`, `clearFilters`, `pagination` > `button`|`info`).
 
 ## Common Patterns
 
 ```tsx
 <Flex d="column" gap={4} ai="center" jc="between">{children}</Flex>
-<Flex d="column" gap={2} md={{ d: 'row', gap: 4 }}>{children}</Flex>  // responsive stack
+<Flex d="column" gap={2} md={{ d: 'row', gap: 4 }}>{children}</Flex>
 <Grid gridCols={3} gap={4}>{items}</Grid>
-<Box p={4} bgColor="white" borderRadius={8} shadow="medium" />        // card
-<Box overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap" />  // truncated text
+<Box p={4} bgColor="white" borderRadius={8} shadow="medium" />
+<Box overflow="hidden" textOverflow="ellipsis" whiteSpace="nowrap" />
 ```
 
 **Group hover**: `<Box hoverGroup={{ 'parent-class': { opacity: 1 } }}>`
 **SSR**: `import { getStyles, resetStyles } from '@cronocode/react-box/ssg'`
-**Portals**: Tooltip component for escaping `overflow: hidden` (renders into `#crono-box` container)
+**Portals**: Tooltip for escaping `overflow: hidden` (renders into `#crono-box`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cronocode/react-box",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "type": "module",
   "main": "./box.cjs",
   "module": "./box.mjs",

--- a/pages/extends.ts
+++ b/pages/extends.ts
@@ -361,7 +361,7 @@ export const components = Box.components({
         children: {
           detailRow: {
             styles: {
-              theme: { dark: { bgColor: 'blue-950' } },
+              theme: { dark: { bgColor: 'gray-900' } },
             },
           },
         },
@@ -386,11 +386,10 @@ export const components = Box.components({
           cell: {
             styles: {
               fontSize: 12,
-              py: 1,
-              bgColor: 'transparent',
+              bgColor: 'gray-900',
               color: 'gray-100',
               fontWeight: 500,
-              theme: { dark: { bgColor: 'transparent', color: 'gray-500' } },
+              theme: { dark: { bgColor: 'gray-800', color: 'gray-500' } },
             },
           },
         },

--- a/pages/pages/dataGridPage.tsx
+++ b/pages/pages/dataGridPage.tsx
@@ -293,7 +293,6 @@ export default function DataGridPage() {
 />`}
           >
             <DataGrid
-              component="subgrid"
               data={allData}
               filters={filters}
               def={{
@@ -646,6 +645,7 @@ export default function DataGridPage() {
           }}
         />
       ),
+      expandColumnHeader: 'Details',
       pinned: true,
     },
   }}
@@ -696,10 +696,16 @@ export default function DataGridPage() {
                     header: 'Total',
                     width: 100,
                     align: 'right',
-                    Cell: ({ cell }) => <Box fontWeight={600}>${cell.row.data.total}</Box>,
+                    Cell: ({ cell }) => (
+                      <Box fontWeight={600} px={2}>
+                        ${cell.row.data.total}
+                      </Box>
+                    ),
                   },
                 ],
+                contextMenu: { pin: false },
                 rowDetail: {
+                  // expandColumnHeader: 'Details',
                   content: (order: (typeof ordersData)[0]) => (
                     <Box p={4}>
                       <Box fontSize={13} fontWeight={600} mb={2} color="gray-600" theme={{ dark: { color: 'gray-400' } }}>
@@ -718,7 +724,7 @@ export default function DataGridPage() {
                               header: 'Price',
                               width: 100,
                               align: 'right',
-                              Cell: ({ cell }) => <Box>${cell.row.data.price}</Box>,
+                              Cell: ({ cell }) => <Box px={2}>${cell.row.data.price}</Box>,
                             },
                           ],
                           visibleRowsCount: 'all',
@@ -728,6 +734,8 @@ export default function DataGridPage() {
                     </Box>
                   ),
                   pinned: true,
+                  expandOnRowClick: true,
+                  expandColumnWidth: 50,
                 },
               }}
             />
@@ -772,6 +780,85 @@ export default function DataGridPage() {
                 visibleRowsCount: 5,
                 sortable: false,
                 resizable: false,
+              }}
+            />
+          </Code>
+
+          <Code
+            id="context-menu"
+            label="Context Menu Control"
+            language="jsx"
+            code={`<DataGrid
+  data={data}
+  def={{
+    columns: [
+      { key: 'first_name', header: 'First name' },
+      { key: 'last_name', header: 'Last name' },
+      { key: 'age', header: 'Age', width: 100, contextMenu: false }, // No context menu
+      { key: 'email', header: 'Email', width: 300, contextMenu: { sort: true, pin: false, group: false } },
+      { key: 'country' },
+      { key: 'city' },
+    ],
+    rowHeight: 40,
+    visibleRowsCount: 5,
+    contextMenu: { sort: true, pin: true, group: false }, // Disable grouping globally
+  }}
+/>`}
+          >
+            <DataGrid
+              data={allData}
+              def={{
+                columns: [
+                  { key: 'first_name', header: 'First name' },
+                  { key: 'last_name', header: 'Last name' },
+                  { key: 'age', header: 'Age', width: 100, contextMenu: false },
+                  { key: 'email', header: 'Email', width: 300, contextMenu: { sort: true, pin: false, group: false } },
+                  { key: 'country' },
+                  { key: 'city' },
+                ],
+                rowHeight: 40,
+                visibleRowsCount: 5,
+                contextMenu: { sort: true, pin: true, group: false },
+              }}
+            />
+          </Code>
+
+          <Code
+            id="resizer-style"
+            label="Resizer Style"
+            language="jsx"
+            code={`// 'hover' — resizer appears only when hovering the header cell
+<DataGrid
+  data={data}
+  def={{
+    columns: [
+      { key: 'first_name', header: 'First name' },
+      { key: 'last_name', header: 'Last name' },
+      { key: 'age', header: 'Age', width: 100 },
+      { key: 'email', header: 'Email', width: 300 },
+      { key: 'country' },
+      { key: 'city' },
+    ],
+    rowHeight: 40,
+    visibleRowsCount: 5,
+    resizerStyle: 'hover', // 'visible' | 'hover' | 'hidden'
+  }}
+/>`}
+          >
+            <DataGrid
+              data={allData}
+              def={{
+                columns: [
+                  { key: 'first_name', header: 'First name' },
+                  { key: 'last_name', header: 'Last name' },
+                  { key: 'age', header: 'Age', width: 100 },
+                  { key: 'email', header: 'Email', width: 300 },
+                  { key: 'country' },
+                  { key: 'city' },
+                ],
+                rowHeight: 40,
+                visibleRowsCount: 5,
+                resizerStyle: 'hover',
               }}
             />
           </Code>

--- a/src/BOX_AI_CONTEXT.md
+++ b/src/BOX_AI_CONTEXT.md
@@ -402,7 +402,9 @@ import DataGrid from '@cronocode/react-box/components/dataGrid';
         Cell: ({ cell }) => <Button onClick={() => edit(cell.row.data)}>Edit</Button>,
       },
     ],
-    rowDetail: { content: (user) => <UserDetails user={user} />, height: 'auto', expandOnRowClick: true },
+    rowDetail: { content: (user) => <UserDetails user={user} />, height: 'auto', expandOnRowClick: true, expandColumnHeader: 'Details' },
+    contextMenu: { sort: true, pin: true, group: false },
+    resizerStyle: 'hover',
   }}
   onSelectionChange={(e) => console.log(e.selectedRowKeys)}
 />
@@ -435,13 +437,15 @@ import DataGrid from '@cronocode/react-box/components/dataGrid';
 | `visibleRowsCount` | `number \| 'all'` | `10` | Visible rows. `'all'` disables virtualization |
 | `showRowNumber` | `boolean \| { pinned?, width? }` | `false` | Row number column |
 | `rowSelection` | `boolean \| { pinned? }` | `false` | Checkbox selection column |
-| `rowDetail` | `{ content, height?, expandOnRowClick?, pinned? }` | — | Expandable detail panel. `height`: `'auto'`/number/`(row) => number` |
+| `rowDetail` | `RowDetailConfig` | — | Expandable detail panel (see below) |
 | `pagination` | `{ totalCount, pageSize? }` | — | Server-side pagination. Bypasses client-side filtering |
 | `topBar` / `bottomBar` | `boolean` | `false` | Show top/bottom bars |
 | `title` / `topBarContent` | `ReactNode` | — | Top bar content |
 | `globalFilter` | `boolean` | `false` | Enable global fuzzy search |
 | `globalFilterKeys` | `(keyof TRow)[]` | all | Limit global filter columns |
 | `sortable` / `resizable` | `boolean` | `true` | Enable sorting/resizing for all columns |
+| `contextMenu` | `boolean \| ContextMenuConfig` | `true` | Control column header context menu. `false` hides it. Object: `{ sort?, pin?, group? }` |
+| `resizerStyle` | `'visible' \| 'hover' \| 'hidden'` | `'visible'` | Resizer handle visibility. `'hover'`: shows on header cell hover. `'hidden'`: invisible but resize still works |
 | `noDataComponent` | `ReactNode` | `'empty'` | Custom empty state |
 
 ### ColumnType
@@ -458,6 +462,26 @@ import DataGrid from '@cronocode/react-box/components/dataGrid';
 | `sortable` / `resizable` | `boolean` | inherits | Override grid-level setting |
 | `flexible` | `boolean` | `true` | Participate in flex width distribution |
 | `filterable` | `boolean \| FilterConfig` | — | `true` (text), `{ type: 'number', min?, max? }`, `{ type: 'multiselect', options? }` |
+| `contextMenu` | `boolean \| ContextMenuConfig` | inherits | Override grid-level context menu. `false` hides entirely. `{ sort?, pin?, group? }` controls sections |
+
+### RowDetailConfig
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `content` | `(row: TRow) => ReactNode` | required | Render function for the detail panel |
+| `height` | `'auto' \| number \| (row) => number` | `'auto'` | Detail row height |
+| `expandOnRowClick` | `boolean` | `false` | Click anywhere on the row to toggle expansion |
+| `pinned` | `boolean` | `false` | Pin the expand column to LEFT |
+| `expandColumnWidth` | `number` | `50` | Width of the expand column in px |
+| `expandColumnHeader` | `string` | `''` | Header text for the expand column |
+
+### ContextMenuConfig
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `sort` | `boolean` | `true` | Show Sort Ascending / Sort Descending / Clear Sort |
+| `pin` | `boolean` | `true` | Show Pin Left / Pin Right / Unpin |
+| `group` | `boolean` | `true` | Show Group By / Un-Group All |
 
 ### Server-Side Pagination
 

--- a/src/components/dataGrid/components/dataGridCellRowDetail.tsx
+++ b/src/components/dataGrid/components/dataGridCellRowDetail.tsx
@@ -11,9 +11,13 @@ export default function DataGridCellRowDetail<TRow>(props: Props<TRow>) {
   const { cell } = props;
   const expanded = cell.grid.expandedDetailRows.has(cell.row.key);
 
-  const toggleHandler = useCallback(() => {
-    cell.grid.toggleDetailRow(cell.row.key);
-  }, [cell.grid, cell.row.key]);
+  const toggleHandler = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      cell.grid.toggleDetailRow(cell.row.key);
+    },
+    [cell.grid, cell.row.key],
+  );
 
   return (
     <Button
@@ -24,6 +28,8 @@ export default function DataGridCellRowDetail<TRow>(props: Props<TRow>) {
       display="flex"
       ai="center"
       jc="center"
+      width="fit"
+      height="fit"
     >
       <ExpandIcon fill="currentColor" width="14px" height="14px" rotate={expanded ? 0 : -90} />
     </Button>

--- a/src/components/dataGrid/components/dataGridDetailRow.tsx
+++ b/src/components/dataGrid/components/dataGridDetailRow.tsx
@@ -22,7 +22,7 @@ export default function DataGridDetailRow<TRow>(props: Props<TRow>) {
         height: isAutoHeight ? 'auto' : `${row.height}px`,
       }}
     >
-      <Box position="sticky" left={0} width="fit" overflow="hidden" style={{ minWidth: '100%' }}>
+      <Box position="sticky" left={0} overflowX="auto" overflowY="hidden" style={{ width: `var(${grid.viewportWidthVarName})` }}>
         {config.content(parentRow.data)}
       </Box>
     </Flex>

--- a/src/components/dataGrid/components/dataGridHeaderCell.tsx
+++ b/src/components/dataGrid/components/dataGridHeaderCell.tsx
@@ -4,7 +4,7 @@ import SortIcon from '../../../icons/sortIcon';
 import Checkbox from '../../checkbox';
 import Flex from '../../flex';
 import ColumnModel from '../models/columnModel';
-import { EMPTY_CELL_KEY, GROUPING_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
+import { EMPTY_CELL_KEY, GROUPING_CELL_KEY, ROW_DETAIL_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
 import DataGridHeaderCellContextMenu from './dataGridHeaderCellContextMenu';
 import DataGridHeaderCellResizer from './dataGridHeaderCellResizer';
 
@@ -37,6 +37,7 @@ export default function DataGridHeaderCell<TRow>(props: Props<TRow>) {
   const isGroupingCell = key === GROUPING_CELL_KEY;
   const isRowNumber = key === ROW_NUMBER_CELL_KEY;
   const isRowSelection = key === ROW_SELECTION_CELL_KEY;
+  const isRowDetailCell = key === ROW_DETAIL_CELL_KEY;
 
   const isLeftPinned = pin === 'LEFT';
   const isRightPinned = pin === 'RIGHT';
@@ -45,12 +46,12 @@ export default function DataGridHeaderCell<TRow>(props: Props<TRow>) {
   const isLastLeftPinned = isLeftPinned && isEdge;
   const isFirstRightPinned = isRightPinned && isEdge;
   const isLastRightPinned = isRightPinned && right === 0;
-  const isSortable = isLeaf && !isEmptyCell && !isRowNumber && !isRowSelection && column.sortable;
+  const isSortable = isLeaf && !isEmptyCell && !isRowNumber && !isRowSelection && !isRowDetailCell && column.sortable;
 
   const gridColumn = isLeaf ? 1 : leafs.length;
 
-  const showResizer = !isRowNumber && !isRowSelection && column.resizable;
-  const showContextMenu = !isRowNumber && !isRowSelection;
+  const showResizer = !isRowNumber && !isRowSelection && !isRowDetailCell && column.resizable;
+  const showContextMenu = !isRowNumber && !isRowSelection && !isRowDetailCell && column.showContextMenu;
 
   const pl = isRowSelection ? undefined : column.align === 'right' ? 10 : 3;
   const pr = isRowSelection ? undefined : column.align === 'center' ? 3 : undefined;
@@ -83,6 +84,7 @@ export default function DataGridHeaderCell<TRow>(props: Props<TRow>) {
   return (
     <Flex
       props={{ role: 'columnheader' }}
+      className="header-cell"
       component={`${grid.componentName}.header.cell` as never}
       variant={
         {

--- a/src/components/dataGrid/components/dataGridHeaderCellContextMenu.tsx
+++ b/src/components/dataGrid/components/dataGridHeaderCellContextMenu.tsx
@@ -23,14 +23,16 @@ export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) 
   const [tooltipPosition, setTooltipPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
   const openLeft = useMemo(() => tooltipPosition.left > window.innerWidth / 2, [tooltipPosition.left]);
 
-  const isSortAscAvailable = isLeaf && column.sortable && (grid.sortColumn !== key || grid.sortDirection === 'DESC');
-  const isSortDescAvailable = isLeaf && column.sortable && (grid.sortColumn !== key || grid.sortDirection === 'ASC');
-  const isClearSortAvailable = isLeaf && column.sortable && grid.sortColumn === key;
-  const isPinLeftAvailable = pin !== 'LEFT';
-  const isPinRightAvailable = pin !== 'RIGHT';
-  const isUnpinAvailable = !!pin;
-  const isGroupByAvailable = isLeaf && key !== GROUPING_CELL_KEY;
-  const isUnGroupByAvailable = isLeaf && key === GROUPING_CELL_KEY;
+  const { sort: showSort, pin: showPin, group: showGroup } = column.contextMenuSections;
+
+  const isSortAscAvailable = showSort && isLeaf && column.sortable && (grid.sortColumn !== key || grid.sortDirection === 'DESC');
+  const isSortDescAvailable = showSort && isLeaf && column.sortable && (grid.sortColumn !== key || grid.sortDirection === 'ASC');
+  const isClearSortAvailable = showSort && isLeaf && column.sortable && grid.sortColumn === key;
+  const isPinLeftAvailable = showPin && pin !== 'LEFT';
+  const isPinRightAvailable = showPin && pin !== 'RIGHT';
+  const isUnpinAvailable = showPin && !!pin;
+  const isGroupByAvailable = showGroup && isLeaf && key !== GROUPING_CELL_KEY;
+  const isUnGroupByAvailable = showGroup && isLeaf && key === GROUPING_CELL_KEY;
 
   const isSortingAvailable = isSortAscAvailable || isSortDescAvailable || isClearSortAvailable;
   const isPiningAvailable = isPinLeftAvailable || isPinRightAvailable || isUnpinAvailable;

--- a/src/components/dataGrid/components/dataGridHeaderCellResizer.tsx
+++ b/src/components/dataGrid/components/dataGridHeaderCellResizer.tsx
@@ -8,6 +8,7 @@ interface Props<TRow> {
 
 export default function DataGridHeaderCellResizer<TRow>(props: Props<TRow>) {
   const { column } = props;
+  const resizerStyle = column.grid.resizerStyle;
 
   return (
     <Flex
@@ -26,7 +27,11 @@ export default function DataGridHeaderCellResizer<TRow>(props: Props<TRow>) {
         height="fit"
         props={{ onMouseDown: column.resizeColumn, onTouchStart: column.resizeColumn }}
       >
-        <Box component={`${column.grid.componentName}.header.cell.resizer` as never} />
+        <Box
+          component={`${column.grid.componentName}.header.cell.resizer` as never}
+          opacity={resizerStyle !== 'visible' ? 0 : undefined}
+          hoverGroup={resizerStyle === 'hover' ? ({ 'header-cell': { opacity: 1 } } as never) : undefined}
+        />
       </Box>
     </Flex>
   );

--- a/src/components/dataGrid/contracts/dataGridContract.ts
+++ b/src/components/dataGrid/contracts/dataGridContract.ts
@@ -92,6 +92,20 @@ export interface RowDetailConfig<TRow> {
   pinned?: boolean;
   /** Width of the expand column. Default: 50 */
   expandColumnWidth?: number;
+  /** Header text for the expand column. Default: '' (empty) */
+  expandColumnHeader?: string;
+}
+
+// ========== Context Menu ==========
+
+/** Controls which sections appear in the column header context menu */
+export interface ContextMenuConfig {
+  /** Show sort actions (Sort Ascending, Sort Descending, Clear Sort). Default: true */
+  sort?: boolean;
+  /** Show pin actions (Pin Left, Pin Right, Unpin). Default: true */
+  pin?: boolean;
+  /** Show group actions (Group By, Un-Group All). Default: true */
+  group?: boolean;
 }
 
 // ========== Column Type ==========
@@ -112,6 +126,8 @@ export interface ColumnType<TRow> {
   resizable?: boolean;
   /** If false, column stays fixed at its width and doesn't participate in flex distribution. Default: true */
   flexible?: boolean;
+  /** Control the header context menu. false hides it entirely. Object controls individual sections. Inherits from GridDefinition.contextMenu if undefined. */
+  contextMenu?: boolean | ContextMenuConfig;
 }
 
 export interface GridDefinition<TRow> {
@@ -136,6 +152,10 @@ export interface GridDefinition<TRow> {
   sortable?: boolean;
   /** Enable resizing for all columns. Default is true. Individual column settings take priority. */
   resizable?: boolean;
+  /** Controls the visual style of column resizer handles. 'visible' (default): always shown. 'hover': visible on header cell hover. 'hidden': invisible but resize still works. */
+  resizerStyle?: 'visible' | 'hover' | 'hidden';
+  /** Control the header context menu for all columns. false hides it entirely. Object controls individual sections. Default: true. Individual column settings take priority. */
+  contextMenu?: boolean | ContextMenuConfig;
   /** Custom component to render when data is empty */
   noDataComponent?: React.ReactNode;
   /** Enable expandable row detail panel */

--- a/src/components/dataGrid/models/columnModel.test.ts
+++ b/src/components/dataGrid/models/columnModel.test.ts
@@ -129,6 +129,84 @@ describe('ColumnModel', () => {
     });
   });
 
+  describe('contextMenu', () => {
+    it('defaults to true when no flags are set', () => {
+      const grid = new GridModel<Person>({ data, def: { columns: [{ key: 'firstName' }] } }, () => {});
+      const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+      expect(col.contextMenu).toBe(true);
+      expect(col.showContextMenu).toBe(true);
+      expect(col.contextMenuSections).toEqual({ sort: true, pin: true, group: true });
+    });
+
+    it('respects global contextMenu: false', () => {
+      const grid = new GridModel<Person>({ data, def: { columns: [{ key: 'firstName' }], contextMenu: false } }, () => {});
+      const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+      expect(col.contextMenu).toBe(false);
+      expect(col.showContextMenu).toBe(false);
+      expect(col.contextMenuSections).toEqual({ sort: false, pin: false, group: false });
+    });
+
+    it('column-level contextMenu: false overrides global true', () => {
+      const grid = new GridModel<Person>(
+        { data, def: { columns: [{ key: 'firstName', contextMenu: false }], contextMenu: true } },
+        () => {},
+      );
+      const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+      expect(col.contextMenu).toBe(false);
+      expect(col.showContextMenu).toBe(false);
+    });
+
+    it('column-level contextMenu: true overrides global false', () => {
+      const grid = new GridModel<Person>(
+        { data, def: { columns: [{ key: 'firstName', contextMenu: true }], contextMenu: false } },
+        () => {},
+      );
+      const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+      expect(col.contextMenu).toBe(true);
+      expect(col.showContextMenu).toBe(true);
+    });
+
+    it('respects global ContextMenuConfig object', () => {
+      const grid = new GridModel<Person>(
+        { data, def: { columns: [{ key: 'firstName' }], contextMenu: { sort: true, pin: false, group: false } } },
+        () => {},
+      );
+      const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+      expect(col.contextMenuSections).toEqual({ sort: true, pin: false, group: false });
+      expect(col.showContextMenu).toBe(true);
+    });
+
+    it('column-level ContextMenuConfig overrides global', () => {
+      const grid = new GridModel<Person>(
+        {
+          data,
+          def: {
+            columns: [{ key: 'firstName', contextMenu: { sort: false, pin: true } }],
+            contextMenu: { sort: true, pin: false, group: false },
+          },
+        },
+        () => {},
+      );
+      const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+      expect(col.contextMenuSections).toEqual({ sort: false, pin: true, group: true });
+    });
+
+    it('showContextMenu returns false when all sections are disabled', () => {
+      const grid = new GridModel<Person>(
+        { data, def: { columns: [{ key: 'firstName', contextMenu: { sort: false, pin: false, group: false } }] } },
+        () => {},
+      );
+      const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+      expect(col.showContextMenu).toBe(false);
+    });
+
+    it('ContextMenuConfig defaults missing keys to true', () => {
+      const grid = new GridModel<Person>({ data, def: { columns: [{ key: 'firstName', contextMenu: { sort: false } }] } }, () => {});
+      const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+      expect(col.contextMenuSections).toEqual({ sort: false, pin: true, group: true });
+    });
+  });
+
   describe('flexible', () => {
     it('isFlexible defaults to true when flexible is undefined', () => {
       const grid = new GridModel<Person>({ data, def: { columns: [{ key: 'firstName' }] } }, () => {});

--- a/src/components/dataGrid/models/columnModel.ts
+++ b/src/components/dataGrid/models/columnModel.ts
@@ -1,5 +1,5 @@
 import FnUtils from '../../../utils/fn/fnUtils';
-import { ColumnType, PinPosition } from '../contracts/dataGridContract';
+import { ColumnType, ContextMenuConfig, PinPosition } from '../contracts/dataGridContract';
 import GridModel, { EMPTY_CELL_KEY } from './gridModel';
 
 export default class ColumnModel<TRow> {
@@ -68,6 +68,34 @@ export default class ColumnModel<TRow> {
       return this.def.resizable;
     }
     return this.grid.props.def.resizable !== false;
+  }
+
+  /** Resolved context menu configuration. Column-level takes priority over grid-level. Default: true. */
+  public get contextMenu(): boolean | ContextMenuConfig {
+    if (this.def.contextMenu !== undefined) {
+      return this.def.contextMenu;
+    }
+    return this.grid.props.def.contextMenu ?? true;
+  }
+
+  /** Whether the context menu button should be shown at all. */
+  public get showContextMenu(): boolean {
+    const config = this.contextMenu;
+    if (typeof config === 'boolean') return config;
+    return config.sort !== false || config.pin !== false || config.group !== false;
+  }
+
+  /** Resolved context menu sections visibility. */
+  public get contextMenuSections(): { sort: boolean; pin: boolean; group: boolean } {
+    const config = this.contextMenu;
+    if (typeof config === 'boolean') {
+      return { sort: config, pin: config, group: config };
+    }
+    return {
+      sort: config.sort !== false,
+      pin: config.pin !== false,
+      group: config.group !== false,
+    };
   }
 
   /** Whether column participates in flex distribution. Default true unless explicitly false. */

--- a/src/components/dataGrid/models/gridModel.test.ts
+++ b/src/components/dataGrid/models/gridModel.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, suite, vi } from 'vitest';
 import { ignoreLogs } from '../../../../dev/tests';
 import { GridDefinition } from '../contracts/dataGridContract';
-import GridModel, { DEFAULT_ROW_NUMBER_COLUMN_WIDTH, ROW_NUMBER_CELL_KEY } from './gridModel';
+import GridModel, { DEFAULT_ROW_NUMBER_COLUMN_WIDTH, ROW_DETAIL_CELL_KEY, ROW_NUMBER_CELL_KEY } from './gridModel';
 import GroupRowModel from './groupRowModel';
 import RowModel from './rowModel';
 
@@ -321,6 +321,94 @@ describe('GridModel', () => {
 
       expect(rowNumberColumn?.inlineWidth).toEqual(129);
       expect(rowNumberColumn?.pin).toEqual('LEFT');
+    });
+  });
+
+  suite('when rowDetail', () => {
+    it('adds expand column with empty header by default', () => {
+      const grid = getGridModel({
+        gridDef: { columns: [{ key: 'firstName' }], rowDetail: { content: () => null } },
+      });
+
+      const expandColumn = grid.columns.value.visibleLeafs.find((x) => x.key === ROW_DETAIL_CELL_KEY);
+      expect(expandColumn).toBeDefined();
+      expect(expandColumn?.header).toBe('');
+    });
+
+    it('uses custom expandColumnHeader', () => {
+      const grid = getGridModel({
+        gridDef: { columns: [{ key: 'firstName' }], rowDetail: { content: () => null, expandColumnHeader: 'Details' } },
+      });
+
+      const expandColumn = grid.columns.value.visibleLeafs.find((x) => x.key === ROW_DETAIL_CELL_KEY);
+      expect(expandColumn?.header).toBe('Details');
+    });
+
+    it('expand column defaults to width 50', () => {
+      const grid = getGridModel({
+        gridDef: { columns: [{ key: 'firstName' }], rowDetail: { content: () => null } },
+      });
+
+      const expandColumn = grid.columns.value.visibleLeafs.find((x) => x.key === ROW_DETAIL_CELL_KEY);
+      expect(expandColumn?.inlineWidth).toBe(50);
+    });
+
+    it('expand column uses custom expandColumnWidth', () => {
+      const grid = getGridModel({
+        gridDef: { columns: [{ key: 'firstName' }], rowDetail: { content: () => null, expandColumnWidth: 80 } },
+      });
+
+      const expandColumn = grid.columns.value.visibleLeafs.find((x) => x.key === ROW_DETAIL_CELL_KEY);
+      expect(expandColumn?.inlineWidth).toBe(80);
+    });
+
+    it('expand column is excluded from userVisibleLeafs', () => {
+      const grid = getGridModel({
+        gridDef: { columns: [{ key: 'firstName' }], rowDetail: { content: () => null } },
+      });
+
+      expect(grid.columns.value.userVisibleLeafs.some((c) => c.key === ROW_DETAIL_CELL_KEY)).toBe(false);
+    });
+  });
+
+  suite('resizerStyle', () => {
+    it('defaults to visible', () => {
+      const grid = getGridModel();
+      expect(grid.resizerStyle).toBe('visible');
+    });
+
+    it('respects hover setting', () => {
+      const grid = getGridModel({ gridDef: { resizerStyle: 'hover' } });
+      expect(grid.resizerStyle).toBe('hover');
+    });
+
+    it('respects hidden setting', () => {
+      const grid = getGridModel({ gridDef: { resizerStyle: 'hidden' } });
+      expect(grid.resizerStyle).toBe('hidden');
+    });
+  });
+
+  suite('viewportWidth CSS variable', () => {
+    it('includes --viewport-width in sizes when container width is set', () => {
+      const grid = getGridModel({ gridDef: { columns: [{ key: 'firstName' }] } });
+      grid.setContainerWidth(800);
+
+      expect(grid.sizes.value['--viewport-width']).toBe('800px');
+    });
+
+    it('does not include --viewport-width when container width is 0', () => {
+      const grid = getGridModel({ gridDef: { columns: [{ key: 'firstName' }] } });
+
+      expect(grid.sizes.value['--viewport-width']).toBeUndefined();
+    });
+
+    it('updates --viewport-width when container is resized', () => {
+      const grid = getGridModel({ gridDef: { columns: [{ key: 'firstName' }] } });
+      grid.setContainerWidth(800);
+      expect(grid.sizes.value['--viewport-width']).toBe('800px');
+
+      grid.setContainerWidth(1200);
+      expect(grid.sizes.value['--viewport-width']).toBe('1200px');
     });
   });
 });

--- a/src/components/dataGrid/models/gridModel.ts
+++ b/src/components/dataGrid/models/gridModel.ts
@@ -38,6 +38,10 @@ export default class GridModel<TRow> {
     return (this.props.component || 'datagrid') as keyof ComponentsAndVariants;
   }
 
+  public get resizerStyle(): 'visible' | 'hover' | 'hidden' {
+    return this.props.def.resizerStyle ?? 'visible';
+  }
+
   public readonly sourceColumns = memo(() => {
     const { def } = this.props;
 
@@ -74,8 +78,11 @@ export default class GridModel<TRow> {
     if (def.rowDetail) {
       const pin: PinPosition | undefined = def.rowDetail.pinned ? 'LEFT' : undefined;
       const width = def.rowDetail.expandColumnWidth ?? 50;
+      const header = def.rowDetail.expandColumnHeader ?? '';
 
-      sourceColumns.unshift(new ColumnModel({ key: ROW_DETAIL_CELL_KEY, pin, width, align: 'center', Cell: DataGridCellRowDetail }, this));
+      sourceColumns.unshift(
+        new ColumnModel({ key: ROW_DETAIL_CELL_KEY, header, pin, width, align: 'center', Cell: DataGridCellRowDetail }, this),
+      );
     }
 
     return sourceColumns;
@@ -91,7 +98,8 @@ export default class GridModel<TRow> {
     const leafs = flat.filter((x) => x.isLeaf);
     const visibleLeafs = flat.filter((x) => x.isLeaf && x.isVisible);
     const userVisibleLeafs = visibleLeafs.filter(
-      (c) => ![EMPTY_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY, GROUPING_CELL_KEY, ROW_DETAIL_CELL_KEY].includes(c.key),
+      (c) =>
+        !([EMPTY_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY, GROUPING_CELL_KEY, ROW_DETAIL_CELL_KEY] as Key[]).includes(c.key),
     );
     const maxDeath = flat.maxBy((x) => x.death) + 1;
 
@@ -501,6 +509,9 @@ export default class GridModel<TRow> {
 
     size[this.rowHeightVarName] = `${this.rowHeight}px`;
     size[this.leftEdgeVarName] = `${this.leftEdge}px`;
+    if (this._containerWidth > 0) {
+      size[this.viewportWidthVarName] = `${this._containerWidth}px`;
+    }
 
     const { visibleLeafs } = this.columns.value;
     const groupingColumn = visibleLeafs.find((c) => c.key === GROUPING_CELL_KEY);
@@ -703,6 +714,7 @@ export default class GridModel<TRow> {
   }
   public readonly leftEdgeVarName = '--left-edge';
   public readonly rowHeightVarName = '--row-height';
+  public readonly viewportWidthVarName = '--viewport-width';
 
   private readonly _idMap = new WeakMap<WeakKey, Key>();
   public getRowKey(row: TRow): Key {

--- a/src/core/extends/boxComponents.ts
+++ b/src/core/extends/boxComponents.ts
@@ -1113,7 +1113,15 @@ const boxComponents = {
             },
           },
           detailRow: {
-            styles: {},
+            styles: {
+              bb: 1,
+              borderColor: 'gray-200',
+              theme: {
+                dark: {
+                  borderColor: 'gray-800',
+                },
+              },
+            },
           },
           row: {
             styles: {},


### PR DESCRIPTION
## Summary
- **expandColumnHeader**: New `RowDetailConfig` prop to set custom header text for the expand column (defaults to empty instead of `'row-detail-cell'`)
- **contextMenu control**: New `contextMenu` prop on both `ColumnType` and `GridDefinition` — hide the 3-dots menu entirely (`false`) or control individual sections (`{ sort?, pin?, group? }`)
- **resizerStyle**: New `GridDefinition` prop (`'visible'` | `'hover'` | `'hidden'`) to control column resizer visibility
- **Detail row scroll**: Detail row content now scrolls horizontally when wider than viewport via `--viewport-width` CSS variable
- **Bug fixes**: `expandOnRowClick` double-toggle on expand button, expand column excluded from sort/context menu/resizer
- **Tests**: 19 new unit tests covering all features
- **Docs**: Updated and compacted BOX_AI_CONTEXT.md and SKILL.md files
- **Version**: Bumped to 3.3.1

## Test plan
- [x] `npm run compile` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run build` passes
- [x] `npm test` passes (359 tests)
- [ ] Visual verification with `npm run dev` on DataGrid demo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)