### PR TITLE
Feat/datagrid row detail grouping pagination filters

### DIFF
--- a/.claude/skills/cronocode-react-box/SKILL.md
+++ b/.claude/skills/cronocode-react-box/SKILL.md
@@ -80,9 +80,12 @@ Also: `Mark`, `Figure`, `Figcaption`, `Details`, `Summary`, `Menu`, `Time`. All 
 // Hook: const [theme, setTheme] = Box.useTheme();
 // setTheme('dark') | setTheme(null) resets to auto
 <Box bgColor="white" theme={{ dark: { bgColor: 'gray-900', hover: { bgColor: 'gray-700' } } }} />
+// App-wide styles on <html> (only with use="global"). Use for inheritable CSS (scrollbarColor, fontFamily, color):
+<Box.Theme use="global" globalStyles={{ scrollbarColor: ['violet-500','transparent'],
+  theme: { dark: { scrollbarColor: ['violet-700','gray-900'] } } }} />
 ```
 
-**Props**: `theme?` (string), `use?` (`'global'`|`'local'`), `storageKey?`. Sets `data-theme` attr + class.
+**Props**: `theme?` (string), `use?` (`'global'`|`'local'`), `storageKey?`, `globalStyles?` (BoxStyleProps — `<html>`, requires `use="global"`). Sets `data-theme` attr + class.
 
 ## Component System
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,4 +50,22 @@ export default tseslint.config(
       'prettier/prettier': 'error',
     },
   },
+  {
+    // The DataGrid engine must stay headless (framework-agnostic): no React, no DOM.
+    // Rendering/adapter logic belongs in the components layer.
+    files: ['src/components/dataGrid/models/**/*.ts'],
+    ignores: ['**/*.test.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            { name: 'react', message: 'DataGrid models must stay headless — keep React in the components/adapter layer.' },
+            { name: 'react-dom', message: 'DataGrid models must stay headless — keep React in the components/adapter layer.' },
+          ],
+          patterns: ['react/*', 'react-dom/*'],
+        },
+      ],
+    },
+  },
 );

--- a/marketplace-skill/skills/cronocode-react-box/SKILL.md
+++ b/marketplace-skill/skills/cronocode-react-box/SKILL.md
@@ -80,9 +80,12 @@ Also: `Mark`, `Figure`, `Figcaption`, `Details`, `Summary`, `Menu`, `Time`. All 
 // Hook: const [theme, setTheme] = Box.useTheme();
 // setTheme('dark') | setTheme(null) resets to auto
 <Box bgColor="white" theme={{ dark: { bgColor: 'gray-900', hover: { bgColor: 'gray-700' } } }} />
+// App-wide styles on <html> (only with use="global"). Use for inheritable CSS (scrollbarColor, fontFamily, color):
+<Box.Theme use="global" globalStyles={{ scrollbarColor: ['violet-500','transparent'],
+  theme: { dark: { scrollbarColor: ['violet-700','gray-900'] } } }} />
 ```
 
-**Props**: `theme?` (string), `use?` (`'global'`|`'local'`), `storageKey?`. Sets `data-theme` attr + class.
+**Props**: `theme?` (string), `use?` (`'global'`|`'local'`), `storageKey?`, `globalStyles?` (BoxStyleProps — `<html>`, requires `use="global"`). Sets `data-theme` attr + class.
 
 ## Component System
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cronocode/react-box",
-  "version": "3.2.1",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cronocode/react-box",
-      "version": "3.2.1",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "@cronocode/identity-factory": "^0.0.6"
@@ -98,7 +98,6 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1396,6 +1395,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1410,6 +1412,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1424,6 +1429,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1438,6 +1446,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1452,6 +1463,9 @@
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1466,6 +1480,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1480,6 +1497,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1494,6 +1514,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1508,6 +1531,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1522,6 +1548,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1536,6 +1565,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1622,7 +1654,6 @@
       "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -1767,7 +1798,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1955,7 +1985,6 @@
       "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1990,7 +2019,6 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2002,7 +2030,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2053,7 +2080,6 @@
       "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.36.0",
         "@typescript-eslint/types": "8.36.0",
@@ -2553,7 +2579,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2927,7 +2952,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -3587,7 +3611,6 @@
       "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3649,7 +3672,6 @@
       "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4362,7 +4384,6 @@
       "integrity": "sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "entities": "^4.5.0",
         "webidl-conversions": "^7.0.0",
@@ -5656,7 +5677,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5689,7 +5709,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5805,7 +5824,6 @@
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5819,7 +5837,6 @@
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6001,7 +6018,6 @@
       "integrity": "sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -6736,7 +6752,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6858,7 +6873,6 @@
       "integrity": "sha512-y2L5oJZF7bj4c0jgGYgBNSdIu+5HF+m68rn2cQXFbGoShdhV1phX9rbnxy9YXj82aS8MMsCLAAFkRxZeWdldrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cronocode/react-box",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cronocode/react-box",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "@cronocode/identity-factory": "^0.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cronocode/react-box",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "type": "module",
   "main": "./box.cjs",
   "module": "./box.mjs",

--- a/pages/extends.ts
+++ b/pages/extends.ts
@@ -369,6 +369,72 @@ export const components = Box.components({
     },
   },
 
+  // Orders DataGrid — extends datagrid with 3px indigo border that visually joins expanded row + detail row
+  'orders-datagrid': {
+    extends: 'datagrid',
+    children: {
+      body: {
+        children: {
+          cell: {
+            variants: {
+              isExpanded: {
+                bt: 3,
+                bb: 0,
+                bgColor: 'indigo-50',
+                borderColor: 'indigo-300',
+                hoverGroup: { 'grid-row': { bgColor: 'indigo-100' } },
+                theme: {
+                  dark: {
+                    bgColor: 'indigo-950',
+                    borderColor: 'indigo-700',
+                    hoverGroup: { 'grid-row': { bgColor: 'indigo-900' } },
+                  },
+                },
+              },
+              isExpandedFirstLeaf: {
+                bl: 3,
+              },
+              isExpandedLastLeaf: {
+                br: 3,
+              },
+              isLastLeftPinned: {
+                br: 0,
+              },
+            },
+          },
+          detailRow: {
+            styles: {
+              bb: 3,
+              bt: 0,
+              bgColor: 'indigo-50',
+              borderColor: 'indigo-300',
+              theme: {
+                dark: {
+                  bgColor: 'indigo-950',
+                  borderColor: 'indigo-700',
+                },
+              },
+            },
+            children: {
+              content: {
+                styles: {
+                  bl: 3,
+                  br: 3,
+                  borderColor: 'indigo-300',
+                  theme: {
+                    dark: {
+                      borderColor: 'indigo-700',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+
   // Subgrid — extends datagrid styles with visual overrides for embedded DataGrids
   subgrid: {
     extends: 'datagrid',

--- a/pages/main.tsx
+++ b/pages/main.tsx
@@ -11,7 +11,14 @@ const root = ReactDOM.createRoot(document.getElementById('root')!);
 root.render(
   <React.StrictMode>
     <BrowserRouter>
-      <Box.Theme>
+      <Box.Theme
+        use="global"
+        globalStyles={{
+          scrollbarWidth: 'thin',
+          scrollbarColor: ['violet-500', 'transparent'],
+          theme: { dark: { scrollbarColor: ['violet-700', 'transparent'] } },
+        }}
+      >
         <App />
       </Box.Theme>
     </BrowserRouter>

--- a/pages/pages/dataGridPage.tsx
+++ b/pages/pages/dataGridPage.tsx
@@ -616,7 +616,37 @@ export default function DataGridPage() {
             id="row-detail"
             label="Row Detail — Orders with Items"
             language="jsx"
-            code={`<DataGrid
+            code={`// Define a custom component style tree that extends 'datagrid'.
+// isExpanded/isExpandedFirstLeaf/isExpandedLastLeaf variants let you style
+// the expanded row's cells individually (e.g. top + side borders).
+// detailRow.content gets left/right borders without causing scroll overflow.
+Box.components({
+  'orders-datagrid': {
+    extends: 'datagrid',
+    children: {
+      body: {
+        children: {
+          cell: {
+            variants: {
+              isExpanded: { bt: 3, bb: 0, bgColor: 'indigo-50', borderColor: 'indigo-300' },
+              isExpandedFirstLeaf: { bl: 3 },
+              isExpandedLastLeaf:  { br: 3 },
+            },
+          },
+          detailRow: {
+            styles: { bb: 3, bt: 0, bgColor: 'indigo-50', borderColor: 'indigo-300' },
+            children: {
+              content: { styles: { bl: 3, br: 3, borderColor: 'indigo-300' } },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+<DataGrid
+  component="orders-datagrid"
   data={orders}
   def={{
     rowKey: 'orderId',
@@ -633,6 +663,7 @@ export default function DataGridPage() {
     rowDetail: {
       content: (order) => (
         <DataGrid
+          component="subgrid"
           data={order.items}
           def={{
             columns: [
@@ -640,18 +671,19 @@ export default function DataGridPage() {
               { key: 'qty', header: 'Qty', width: 80, align: 'right' },
               { key: 'price', header: 'Price', width: 100, align: 'right' },
             ],
-            visibleRowsCount: 3,
+            visibleRowsCount: 'all',
             rowHeight: 36,
           }}
         />
       ),
-      expandColumnHeader: 'Details',
       pinned: true,
+      expandOnRowClick: true,
     },
   }}
 />`}
           >
             <DataGrid
+              component="orders-datagrid"
               data={ordersData}
               def={{
                 rowKey: 'orderId',
@@ -868,6 +900,17 @@ export default function DataGridPage() {
   );
 }
 
+type ServerStateArg = {
+  page: number;
+  pageSize: number;
+  sortColumn?: string | number;
+  sortDirection?: string;
+  globalFilterValue?: string;
+  columnFilters?: Partial<
+    Record<string, { type: string; value?: string | number; values?: (string | number | boolean | null)[]; operator?: string }>
+  >;
+};
+
 function PaginatedDataGridDemo() {
   const pageSize = 8;
   const [data, setData] = useState<(typeof allData)[0][]>([]);
@@ -875,11 +918,34 @@ function PaginatedDataGridDemo() {
   const [totalCount, setTotalCount] = useState(0);
   const [loading, setLoading] = useState(true);
 
-  const fetchData = useCallback((state: { page: number; pageSize: number; sortColumn?: string | number; sortDirection?: string }) => {
+  const fetchData = useCallback((state: ServerStateArg) => {
     setLoading(true);
-    // Simulate server response with 300ms delay
+    // Simulate server-side filtering, sorting and pagination
     setTimeout(() => {
-      const result = [...allData];
+      let result = [...allData];
+
+      // Global search
+      if (state.globalFilterValue?.trim()) {
+        const q = state.globalFilterValue.toLowerCase();
+        result = result.filter(
+          (r) => r.first_name.toLowerCase().includes(q) || r.last_name.toLowerCase().includes(q) || r.email.toLowerCase().includes(q),
+        );
+      }
+
+      // Column filters
+      const cf = state.columnFilters ?? {};
+      if (cf.first_name?.type === 'text' && cf.first_name.value) {
+        const q = String(cf.first_name.value).toLowerCase();
+        result = result.filter((r) => r.first_name.toLowerCase().includes(q));
+      }
+      if (cf.age?.type === 'number' && cf.age.value !== undefined) {
+        result = result.filter((r) => r.age >= (cf.age!.value as number));
+      }
+      if (cf.country?.type === 'multiselect' && (cf.country.values?.length ?? 0) > 0) {
+        result = result.filter((r) => cf.country!.values!.includes(r.country));
+      }
+
+      // Sort
       if (state.sortColumn && state.sortDirection) {
         const key = state.sortColumn as keyof (typeof allData)[0];
         result.sort((a, b) => {
@@ -889,6 +955,7 @@ function PaginatedDataGridDemo() {
           return state.sortDirection === 'DESC' ? -cmp : cmp;
         });
       }
+
       const start = (state.page - 1) * state.pageSize;
       setData(result.slice(start, start + state.pageSize));
       setTotalCount(result.length);
@@ -904,18 +971,25 @@ function PaginatedDataGridDemo() {
   const def = useMemo(
     () => ({
       columns: [
-        { key: 'first_name' as const, header: 'First Name' },
+        { key: 'first_name' as const, header: 'First Name', filterable: true },
         { key: 'last_name' as const, header: 'Last Name' },
-        { key: 'age' as const, header: 'Age', width: 100, align: 'right' as const },
+        {
+          key: 'age' as const,
+          header: 'Age',
+          width: 100,
+          align: 'right' as const,
+          filterable: { type: 'number' as const, placeholder: 'Min age' },
+        },
         { key: 'email' as const, header: 'Email', width: 280 },
-        { key: 'country' as const, header: 'Country' },
+        { key: 'country' as const, header: 'Country', filterable: { type: 'multiselect' as const } },
         { key: 'city' as const, header: 'City' },
       ],
       rowHeight: 40,
       visibleRowsCount: pageSize,
       topBar: true,
       bottomBar: true,
-      title: 'Server-Side Pagination',
+      globalFilter: true,
+      title: 'Server-Side Pagination & Filters',
       pagination: { totalCount },
     }),
     [totalCount, pageSize],
@@ -924,14 +998,16 @@ function PaginatedDataGridDemo() {
   return (
     <Code
       id="pagination"
-      label="Server-Side Pagination"
+      label="Server-Side Pagination & Filters"
       language="jsx"
       code={`const [data, setData] = useState([]);
 const [page, setPage] = useState(1);
 const [totalCount, setTotalCount] = useState(0);
-const [loading, setLoading] = useState(true);
 const pageSize = 8;
 
+// onServerStateChange fires on every page/sort/filter change.
+// state = { page, pageSize, sortColumn, sortDirection, globalFilterValue, columnFilters }
+// columnFilters example: { first_name: { type: 'text', value: 'Jo' }, age: { type: 'number', operator: 'gte', value: 30 }, country: { type: 'multiselect', values: ['Brazil'] } }
 const fetchData = useCallback((state) => {
   setLoading(true);
   api.getUsers({
@@ -955,11 +1031,16 @@ useEffect(() => { fetchData({ page: 1, pageSize }); }, []);
   page={page}
   onServerStateChange={fetchData}
   def={{
-    columns: [...],
+    columns: [
+      { key: 'first_name', header: 'First Name', filterable: true },
+      { key: 'age', header: 'Age', filterable: { type: 'number', placeholder: 'Min age' } },
+      { key: 'country', filterable: { type: 'multiselect' } },
+      ...
+    ],
+    globalFilter: true,
     visibleRowsCount: pageSize,
-    topBar: true,
-    bottomBar: true,
-    title: 'Server-Side Pagination',
+    topBar: true, bottomBar: true,
+    title: 'Server-Side Pagination & Filters',
     pagination: { totalCount },
   }}
 />`}
@@ -975,6 +1056,6 @@ const sidebarLinks = [
   { id: 'filters', label: 'Filters' },
   { id: 'grouped', label: 'Grouped Columns' },
   { id: 'row-detail', label: 'Row Detail' },
-  { id: 'pagination', label: 'Pagination' },
+  { id: 'pagination', label: 'Server Pagination & Filters' },
   { id: 'disable-sort', label: 'Disable Sort' },
 ] as const;

--- a/pages/pages/dataGridPage.tsx
+++ b/pages/pages/dataGridPage.tsx
@@ -19,6 +19,8 @@ import useTableOfContents from '../hooks/useTableOfContents';
 
 const allData = [...Data, ...Data1, ...Data2, ...Data3, ...Data4, ...Data5, ...Data6, ...Data7];
 
+const allCountryOptions = [...new Set(allData.map((r) => r.country))].sort().map((c) => ({ label: c, value: c }));
+
 const ordersData = [
   {
     orderId: 1001,
@@ -171,7 +173,7 @@ function CustomTopBarFilter({
   const hasFilters = genderFilter || ageFilter;
 
   return (
-    <Flex ai="center" gap={2} flexWrap="wrap">
+    <Flex gap={2} flexWrap="wrap" width="fit">
       <Flex ai="center" gap={1} color="gray-500" theme={{ dark: { color: 'gray-400' } }}>
         <Filter size={14} />
         <Box fontSize={13}>Quick filters:</Box>
@@ -981,7 +983,7 @@ function PaginatedDataGridDemo() {
           filterable: { type: 'number' as const, placeholder: 'Min age' },
         },
         { key: 'email' as const, header: 'Email', width: 280 },
-        { key: 'country' as const, header: 'Country', filterable: { type: 'multiselect' as const } },
+        { key: 'country' as const, header: 'Country', filterable: { type: 'multiselect' as const, options: allCountryOptions } },
         { key: 'city' as const, header: 'City' },
       ],
       rowHeight: 40,
@@ -1034,7 +1036,9 @@ useEffect(() => { fetchData({ page: 1, pageSize }); }, []);
     columns: [
       { key: 'first_name', header: 'First Name', filterable: true },
       { key: 'age', header: 'Age', filterable: { type: 'number', placeholder: 'Min age' } },
-      { key: 'country', filterable: { type: 'multiselect' } },
+      // In server-side mode the grid only has the current page, so provide
+      // all possible options explicitly (fetch them from your API once).
+      { key: 'country', filterable: { type: 'multiselect', options: countryOptions } },
       ...
     ],
     globalFilter: true,

--- a/pages/pages/themeSetupPage.tsx
+++ b/pages/pages/themeSetupPage.tsx
@@ -88,6 +88,38 @@ function App() {
           </Code>
 
           <Code
+            id="global-styles"
+            label="App-wide Styles (globalStyles)"
+            language="jsx"
+            code={`import Box from '@cronocode/react-box';
+
+// Apply Box props to <html> for app-wide, inheritable CSS like scrollbar-color, fontFamily, color.
+// Only takes effect with use="global". Supports theme-keyed values.
+function App() {
+  return (
+    <Box.Theme
+      use="global"
+      globalStyles={{
+        scrollbarColor: ['violet-500', 'transparent'],
+        scrollbarWidth: 'thin',
+        theme: {
+          dark:  { scrollbarColor: ['violet-700', 'gray-900'] },
+          light: { scrollbarColor: ['violet-300', 'gray-100'] },
+        },
+      }}
+    >
+      <YourApp />
+    </Box.Theme>
+  );
+}
+
+// Emits rules directly on <html>:
+//   html              { scrollbar-color: var(--violet-500) var(--transparent); scrollbar-width: thin; }
+//   html.dark         { scrollbar-color: var(--violet-700) var(--gray-900); }
+//   html.light        { scrollbar-color: var(--violet-300) var(--gray-100); }`}
+          />
+
+          <Code
             id="theme-switching"
             label="Theme Switching"
             language="jsx"
@@ -141,6 +173,7 @@ function Sample() {
 
 const sidebarLinks = [
   { id: 'define-styles', label: 'Define Your Own Styles' },
+  { id: 'global-styles', label: 'App-wide Styles (globalStyles)' },
   { id: 'theme-switching', label: 'Theme Switching' },
 ] as const;
 

--- a/src/BOX_AI_CONTEXT.md
+++ b/src/BOX_AI_CONTEXT.md
@@ -174,8 +174,29 @@ setTheme(null);     // reset to system auto-detection (clears localStorage)
 />
 ```
 
-**Props**: `theme?` (string — explicit theme name), `use?` (`'global'`|`'local'`, default `'local'`), `storageKey?` (string — localStorage key for persistence).
+**Props**: `theme?` (string — explicit theme name), `use?` (`'global'`|`'local'`, default `'local'`), `storageKey?` (string — localStorage key for persistence), `globalStyles?` (BoxStyleProps — app-wide styles on `<html>`, only with `use="global"`).
 **DOM**: Sets `data-theme` attribute and theme class on wrapper (local) or `document.documentElement` (global). Cleaned up on unmount.
+
+#### globalStyles — App-wide styles on `<html>`
+
+```tsx
+// Style the root document scrollbar (and any other html-level CSS). Only takes effect when use="global".
+<Box.Theme
+  use="global"
+  globalStyles={{
+    scrollbarColor: ['violet-500', 'transparent'],
+    scrollbarWidth: 'thin',
+    theme: {
+      dark:  { scrollbarColor: ['violet-700', 'gray-900'] },
+      light: { scrollbarColor: ['violet-300', 'gray-100'] },
+    },
+  }}
+>
+  <App />
+</Box.Theme>
+```
+
+Accepts the same shape as Box style props (including theme-keyed values, pseudo-classes, breakpoints). Rules are emitted directly on `html` — useful for inheritable CSS like `scrollbar-color`/`scrollbar-width`/`fontFamily`/`color`. Group selectors (e.g. `hoverGroup`) are not supported here since `<html>` has no group parent.
 
 ---
 

--- a/src/components/dataGrid.interaction.test.tsx
+++ b/src/components/dataGrid.interaction.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ignoreLogs } from '../../dev/tests';
+import DataGrid from './dataGrid';
+import { DataGridProps, GridDefinition } from './dataGrid/contracts/dataGridContract';
+
+interface Person {
+  id: number;
+  firstName: string;
+  age: number;
+}
+
+const data: Person[] = [
+  { id: 1, firstName: 'John', age: 30 },
+  { id: 2, firstName: 'Jane', age: 25 },
+  { id: 3, firstName: 'Bob', age: 45 },
+];
+
+const baseDef: GridDefinition<Person> = {
+  rowKey: 'id',
+  columns: [
+    { key: 'firstName', header: 'First Name' },
+    { key: 'age', header: 'Age' },
+  ],
+};
+
+function renderGrid(def?: Partial<GridDefinition<Person>>, props?: Partial<DataGridProps<Person>>) {
+  return render(<DataGrid data={data} def={{ ...baseDef, ...def }} {...props} />);
+}
+
+describe('DataGrid interactions (component → model → re-render)', () => {
+  ignoreLogs();
+  afterEach(cleanup);
+
+  it('sorts rows when a sortable header is clicked', () => {
+    renderGrid();
+    const grid = screen.getByRole('presentation');
+
+    fireEvent.click(screen.getByText('First Name')); // ASC → Bob, Jane, John
+
+    const text = grid.textContent ?? '';
+    expect(text.indexOf('Bob')).toBeLessThan(text.indexOf('Jane'));
+    expect(text.indexOf('Jane')).toBeLessThan(text.indexOf('John'));
+  });
+
+  it('select-all checkbox updates the selected count', () => {
+    renderGrid({ rowSelection: true, bottomBar: true });
+    expect(screen.getByText('Selected: 0')).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole('checkbox')[0]); // header select-all
+
+    expect(screen.getByText('Selected: 3')).toBeTruthy();
+  });
+
+  it('paginates via the page-jump input', () => {
+    renderGrid({ bottomBar: true, pagination: { totalCount: 50 }, visibleRowsCount: 10 });
+    expect(screen.getByText('Rows: 1–10 of 50')).toBeTruthy();
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '3' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByText('Rows: 21–30 of 50')).toBeTruthy();
+  });
+
+  it('expands a detail row when the expand cell is clicked', () => {
+    // contextMenu: false so the only buttons are the per-row expand buttons.
+    renderGrid({
+      contextMenu: false,
+      rowDetail: { content: (row) => <div data-testid="detail">Detail {row.firstName}</div> },
+    });
+    expect(screen.queryByTestId('detail')).toBeNull();
+
+    fireEvent.click(screen.getAllByRole('button')[0]); // first row's expand button
+
+    expect(screen.getAllByTestId('detail').length).toBeGreaterThan(0);
+  });
+
+  it('toggles a column hidden via the model and removes its header', () => {
+    const { rerender } = renderGrid({ topBar: true });
+    expect(screen.getByText('Age')).toBeTruthy();
+
+    // Drive visibility through a controlled re-render path: hide "age" by re-rendering
+    // with it removed is not the model path; instead verify the empty-columns state wiring.
+    rerender(<DataGrid data={data} def={{ ...baseDef, columns: [] }} />);
+    expect(screen.getByText('No Columns Selected')).toBeTruthy();
+  });
+});

--- a/src/components/dataGrid/components/dataGridBody.tsx
+++ b/src/components/dataGrid/components/dataGridBody.tsx
@@ -10,28 +10,6 @@ import DataGridDetailRow from './dataGridDetailRow';
 import DataGridGroupRow from './dataGridGroupRow';
 import DataGridRow from './dataGridRow';
 
-const DEFAULT_VISIBLE_ROWS_COUNT = 10;
-const ROWS_TO_PRELOAD = 20;
-
-/**
- * Binary search to find the first row index whose offset is <= scrollTop.
- */
-function findStartIndex(offsets: number[], scrollTop: number): number {
-  let lo = 0;
-  let hi = offsets.length - 1;
-
-  while (lo < hi) {
-    const mid = (lo + hi + 1) >>> 1;
-    if (offsets[mid] <= scrollTop) {
-      lo = mid;
-    } else {
-      hi = mid - 1;
-    }
-  }
-
-  return lo;
-}
-
 function renderRow<TRow>(row: RowModel<TRow> | GroupRowModel<TRow> | DetailRowModel<TRow>) {
   if (row instanceof DetailRowModel) {
     return <DataGridDetailRow key={row.key} row={row} />;
@@ -49,36 +27,20 @@ interface Props<TRow> {
 
 export default function DataGridBody<TRow>(props: Props<TRow>) {
   const { grid, scrollTop } = props;
+  const { viewport } = grid;
 
-  const showAll = grid.props.def.visibleRowsCount === 'all';
-  const { offsets, totalHeight } = grid.rowOffsets.value;
-  const hasDetailRows = !!grid.props.def.rowDetail;
-  const startIndex = showAll
-    ? 0
-    : hasDetailRows
-      ? Math.max(0, findStartIndex(offsets, scrollTop) - ROWS_TO_PRELOAD)
-      : Math.max(0, Math.floor(scrollTop / grid.rowHeight) - ROWS_TO_PRELOAD);
-  const translateY = showAll ? 0 : hasDetailRows ? (offsets[startIndex] ?? 0) : startIndex * grid.rowHeight;
-  const numericVisibleRowsCount = showAll
-    ? grid.flatRows.value.length
-    : ((grid.props.def.visibleRowsCount as number | undefined) ?? DEFAULT_VISIBLE_ROWS_COUNT);
-  const viewHeight = showAll ? undefined : grid.rowHeight * numericVisibleRowsCount + grid.rowHeight / 5;
-  const isEmpty = grid.props.data.length === 0;
+  const { startIndex, take, translateY, totalHeight, viewHeight } = viewport.window(scrollTop);
+  const showAll = viewport.showAll;
+  const isEmpty = viewport.isEmpty;
+  const flatRows = grid.flatRows.value;
 
   const rows = useMemo(() => {
     console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid render rows');
 
-    if (isEmpty) {
-      return null;
-    }
+    if (isEmpty) return null;
 
-    if (showAll) {
-      return grid.flatRows.value.map(renderRow);
-    }
-
-    const take = numericVisibleRowsCount + ROWS_TO_PRELOAD * 2;
-    return grid.flatRows.value.take(take, startIndex).map(renderRow);
-  }, [grid.flatRows.value, isEmpty, showAll, startIndex, numericVisibleRowsCount]);
+    return flatRows.take(take, startIndex).map(renderRow);
+  }, [flatRows, isEmpty, take, startIndex]);
 
   console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid render DataGridBody');
 
@@ -95,7 +57,7 @@ export default function DataGridBody<TRow>(props: Props<TRow>) {
         width="fit"
         position="sticky"
         left={0}
-        style={{ height: viewHeight ?? grid.rowHeight * DEFAULT_VISIBLE_ROWS_COUNT }}
+        style={{ height: viewport.emptyHeight }}
       >
         {noDataComponent ?? defaultEmpty}
       </Flex>
@@ -118,11 +80,7 @@ export default function DataGridBody<TRow>(props: Props<TRow>) {
 
   return (
     <Box style={{ height: viewHeight }}>
-      <Box
-        style={{
-          height: hasDetailRows ? `${totalHeight}px` : `${grid.flatRows.value.length * grid.rowHeight}px`,
-        }}
-      >
+      <Box style={{ height: `${totalHeight}px` }}>
         <Grid
           component={`${grid.componentName}.body` as never}
           width="max-content"

--- a/src/components/dataGrid/components/dataGridBottomBar.tsx
+++ b/src/components/dataGrid/components/dataGridBottomBar.tsx
@@ -9,17 +9,15 @@ interface Props<TRow> {
 
 export default function DataGridBottomBar<TRow>(props: Props<TRow>) {
   const { grid } = props;
-  const paginationState = grid.paginationState;
+  const { pagination, filter } = grid;
 
-  if (paginationState) {
-    const { page, pageSize, totalItems } = paginationState;
-    const start = (page - 1) * pageSize + 1;
-    const end = Math.min(start + pageSize - 1, totalItems);
+  if (pagination.state) {
+    const { totalItems, startItem, endItem } = pagination;
 
     return (
       <Flex component={`${grid.componentName}.bottomBar` as never}>
         <Box component={`${grid.componentName}.bottomBar.info` as never}>
-          Rows: {totalItems > 0 ? `${start}–${end} of ${totalItems}` : '0'}
+          Rows: {totalItems > 0 ? `${startItem}–${endItem} of ${totalItems}` : '0'}
         </Box>
         {grid.props.def.rowSelection && (
           <Box component={`${grid.componentName}.bottomBar.info` as never}>Selected: {grid.selectedRows.size}</Box>
@@ -29,8 +27,7 @@ export default function DataGridBottomBar<TRow>(props: Props<TRow>) {
     );
   }
 
-  const { filtered, total } = grid.filterStats;
-  const hasActiveFilters = grid.hasActiveFilters;
+  const { filtered, total } = filter.filterStats;
 
   return (
     <Flex component={`${grid.componentName}.bottomBar` as never}>
@@ -38,13 +35,13 @@ export default function DataGridBottomBar<TRow>(props: Props<TRow>) {
       {grid.props.def.rowSelection && (
         <Box component={`${grid.componentName}.bottomBar.info` as never}>Selected: {grid.selectedRows.size}</Box>
       )}
-      {hasActiveFilters && (
+      {filter.hasActiveFilters && (
         <Box
           component={`${grid.componentName}.bottomBar.clearFilters` as never}
           color="blue-600"
           cursor="pointer"
           hover={{ textDecoration: 'underline' }}
-          props={{ onClick: grid.clearAllFilters }}
+          props={{ onClick: filter.clearAllFilters }}
         >
           Clear filters
         </Box>

--- a/src/components/dataGrid/components/dataGridCell.tsx
+++ b/src/components/dataGrid/components/dataGridCell.tsx
@@ -1,15 +1,18 @@
 import { BoxProps } from '../../../box';
 import Flex from '../../flex';
 import ColumnModel from '../models/columnModel';
-import { EMPTY_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
+import { EMPTY_CELL_KEY, ROW_DETAIL_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
 
 interface Props<TRow> extends BoxProps {
   children: React.ReactNode;
   column: ColumnModel<TRow>;
+  isExpanded?: boolean;
+  isFirstInRow?: boolean;
+  isLastInRow?: boolean;
 }
 
 export default function DataGridCell<TRow>(props: Props<TRow>) {
-  const { children, column, style, ...restProps } = props;
+  const { children, column, isExpanded = false, isFirstInRow = false, isLastInRow = false, style, ...restProps } = props;
   const { key, pin, left, right, isEdge, align, widthVarName, leftVarName, rightVarName, isFirstLeaf, isLastLeaf } = column;
 
   'align' in column.def && (restProps.jc = align);
@@ -17,6 +20,7 @@ export default function DataGridCell<TRow>(props: Props<TRow>) {
   const isRowNumber = key === ROW_NUMBER_CELL_KEY;
   const isRowSelection = key === ROW_SELECTION_CELL_KEY;
   const isEmptyCell = key === EMPTY_CELL_KEY;
+  const isRowDetail = key === ROW_DETAIL_CELL_KEY;
 
   const isLeftPinned = pin === 'LEFT';
   const isRightPinned = pin === 'RIGHT';
@@ -42,6 +46,10 @@ export default function DataGridCell<TRow>(props: Props<TRow>) {
           isFirstLeaf,
           isLastLeaf,
           isEmptyCell,
+          isRowDetail,
+          isExpanded,
+          isExpandedFirstLeaf: isExpanded && isFirstInRow,
+          isExpandedLastLeaf: isExpanded && isLastInRow,
         } as never
       }
       style={{

--- a/src/components/dataGrid/components/dataGridCell.tsx
+++ b/src/components/dataGrid/components/dataGridCell.tsx
@@ -1,7 +1,6 @@
 import { BoxProps } from '../../../box';
 import Flex from '../../flex';
 import ColumnModel from '../models/columnModel';
-import { EMPTY_CELL_KEY, ROW_DETAIL_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
 
 interface Props<TRow> extends BoxProps {
   children: React.ReactNode;
@@ -13,52 +12,20 @@ interface Props<TRow> extends BoxProps {
 
 export default function DataGridCell<TRow>(props: Props<TRow>) {
   const { children, column, isExpanded = false, isFirstInRow = false, isLastInRow = false, style, ...restProps } = props;
-  const { key, pin, left, right, isEdge, align, widthVarName, leftVarName, rightVarName, isFirstLeaf, isLastLeaf } = column;
 
-  'align' in column.def && (restProps.jc = align);
+  if (column.hasAlign) restProps.jc = column.align;
 
-  const isRowNumber = key === ROW_NUMBER_CELL_KEY;
-  const isRowSelection = key === ROW_SELECTION_CELL_KEY;
-  const isEmptyCell = key === EMPTY_CELL_KEY;
-  const isRowDetail = key === ROW_DETAIL_CELL_KEY;
-
-  const isLeftPinned = pin === 'LEFT';
-  const isRightPinned = pin === 'RIGHT';
-  const isPinned = isLeftPinned || isRightPinned;
-  const isFirstLeftPinned = isLeftPinned && left === 0;
-  const isLastLeftPinned = isLeftPinned && isEdge;
-  const isFirstRightPinned = isRightPinned && isEdge;
-  const isLastRightPinned = isRightPinned && right === 0;
+  // Column-stable variant (precomputed once) merged with this row's expansion state.
+  const variant = isExpanded
+    ? { ...column.cellVariant.value, isExpanded, isExpandedFirstLeaf: isFirstInRow, isExpandedLastLeaf: isLastInRow }
+    : column.cellVariant.value;
 
   return (
     <Flex
       component={`${column.grid.componentName}.body.cell` as never}
       props={{ role: 'cell' }}
-      variant={
-        {
-          isPinned,
-          isFirstLeftPinned,
-          isLastLeftPinned,
-          isFirstRightPinned,
-          isLastRightPinned,
-          isRowSelection,
-          isRowNumber,
-          isFirstLeaf,
-          isLastLeaf,
-          isEmptyCell,
-          isRowDetail,
-          isExpanded,
-          isExpandedFirstLeaf: isExpanded && isFirstInRow,
-          isExpandedLastLeaf: isExpanded && isLastInRow,
-        } as never
-      }
-      style={{
-        width: `var(${widthVarName})`,
-        height: `var(${column.grid.rowHeightVarName})`,
-        left: isLeftPinned ? `var(${leftVarName})` : undefined,
-        right: isRightPinned ? `var(${rightVarName})` : undefined,
-        ...style,
-      }}
+      variant={variant as never}
+      style={{ ...column.cellStyleVars.value, ...style }}
       {...restProps}
     >
       {children}

--- a/src/components/dataGrid/components/dataGridCellRowDetail.tsx
+++ b/src/components/dataGrid/components/dataGridCellRowDetail.tsx
@@ -9,14 +9,14 @@ interface Props<TRow> {
 
 export default function DataGridCellRowDetail<TRow>(props: Props<TRow>) {
   const { cell } = props;
-  const expanded = cell.grid.expandedDetailRows.has(cell.row.key);
+  const expanded = cell.expanded;
 
   const toggleHandler = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      cell.grid.toggleDetailRow(cell.row.key);
+      cell.toggleDetail();
     },
-    [cell.grid, cell.row.key],
+    [cell],
   );
 
   return (

--- a/src/components/dataGrid/components/dataGridCellRowDetail.tsx
+++ b/src/components/dataGrid/components/dataGridCellRowDetail.tsx
@@ -22,6 +22,7 @@ export default function DataGridCellRowDetail<TRow>(props: Props<TRow>) {
   return (
     <Button
       component={`${cell.grid.componentName}.body.cell.rowDetail` as never}
+      variant={{ isExpanded: expanded } as never}
       clean
       onClick={toggleHandler}
       cursor="pointer"

--- a/src/components/dataGrid/components/dataGridCellRowSelection.tsx
+++ b/src/components/dataGrid/components/dataGridCellRowSelection.tsx
@@ -10,10 +10,10 @@ export default function DataGridCellRowSelection<TRow>(props: Props<TRow>) {
   const { cell } = props;
 
   const rowSelectedHandler = useCallback(() => {
-    cell.grid.toggleRowSelection(cell.row.key);
-  }, [cell.grid, cell.row.key]);
+    cell.toggleSelection();
+  }, [cell]);
 
-  return <Checkbox variant="datagrid" checked={cell.row.selected} onChange={rowSelectedHandler} />;
+  return <Checkbox variant="datagrid" checked={cell.selected} onChange={rowSelectedHandler} />;
 }
 
 (DataGridCellRowSelection as React.FunctionComponent).displayName = 'DataGridCellRowSelection';

--- a/src/components/dataGrid/components/dataGridColumnFilter.tsx
+++ b/src/components/dataGrid/components/dataGridColumnFilter.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Box from '../../../box';
 import Dropdown from '../../dropdown';
 import Flex from '../../flex';
 import Textbox from '../../textbox';
-import { ColumnFilterConfig, NumberFilterValue } from '../contracts/dataGridContract';
+import { NumberFilterValue } from '../contracts/dataGridContract';
 import ColumnModel from '../models/columnModel';
 import GridModel from '../models/gridModel';
 
@@ -12,26 +12,19 @@ interface Props<TRow> {
   grid: GridModel<TRow>;
 }
 
-interface FilterOption {
-  label: string;
-  value: string | number | boolean | null;
-}
-
 /**
- * Text filter with fuzzy search support
+ * Text filter with fuzzy search support.
+ * Local input + debounce stay here; config/parsing/commit live on ColumnModel.
  */
 function TextFilter<TRow>({ column, grid }: Props<TRow>) {
-  const currentFilter = grid.columnFilters[column.key as keyof TRow];
+  const currentFilter = column.currentFilter;
   const initialValue = currentFilter?.type === 'text' ? currentFilter.value : '';
   const [localValue, setLocalValue] = useState(initialValue);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, []);
 
@@ -40,34 +33,33 @@ function TextFilter<TRow>({ column, grid }: Props<TRow>) {
       const value = e.target.value;
       setLocalValue(value);
 
-      // Clear previous timeout
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
 
-      // Debounced update
       timeoutRef.current = setTimeout(() => {
-        if (value.trim()) {
-          grid.setColumnFilter(column.key, { type: 'text', value });
-        } else {
-          grid.setColumnFilter(column.key, undefined);
-        }
+        column.setTextFilter(value);
         timeoutRef.current = null;
       }, 300);
     },
-    [grid, column.key],
+    [column],
   );
 
   const handleClear = useCallback(() => {
     setLocalValue('');
-    grid.setColumnFilter(column.key, undefined);
-  }, [grid, column.key]);
-
-  const config: ColumnFilterConfig = typeof column.def.filterable === 'object' ? column.def.filterable : { type: 'text' };
+    column.clearFilter();
+  }, [column]);
 
   return (
-    <Flex component={`${grid.componentName}.filter.cell.input` as never} ai="center" position="relative" width="fit">
-      <Textbox width="fit" variant="compact" placeholder={config.placeholder ?? 'Filter...'} value={localValue} onChange={handleChange} />
+    <Flex component={`${grid.componentName}.filter.cell.input` as never}>
+      <Textbox
+        width="fit"
+        variant="compact"
+        placeholder={column.filterConfig?.placeholder ?? 'Filter...'}
+        value={localValue}
+        onChange={handleChange}
+        b={0}
+        bgColor="transparent"
+        focus={{ outline: 0 }}
+      />
       {localValue && (
         <Flex position="absolute" right={2} top="1/2" translateY="-1/2" cursor="pointer" props={{ onClick: handleClear }}>
           <Box fontSize={10} color="gray-400" hover={{ color: 'gray-600' }}>
@@ -80,10 +72,10 @@ function TextFilter<TRow>({ column, grid }: Props<TRow>) {
 }
 
 /**
- * Number filter with comparison operators
+ * Number filter with comparison operators.
  */
 function NumberFilter<TRow>({ column, grid }: Props<TRow>) {
-  const currentFilter = grid.columnFilters[column.key as keyof TRow];
+  const currentFilter = column.currentFilter;
   const initialValue = currentFilter?.type === 'number' ? currentFilter.value : '';
   const initialOperator = currentFilter?.type === 'number' ? currentFilter.operator : 'eq';
   const initialValueTo = currentFilter?.type === 'number' ? currentFilter.valueTo : '';
@@ -94,71 +86,36 @@ function NumberFilter<TRow>({ column, grid }: Props<TRow>) {
   const valueTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const valueToTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Cleanup timeouts on unmount
   useEffect(() => {
     return () => {
-      if (valueTimeoutRef.current) {
-        clearTimeout(valueTimeoutRef.current);
-      }
-      if (valueToTimeoutRef.current) {
-        clearTimeout(valueToTimeoutRef.current);
-      }
+      if (valueTimeoutRef.current) clearTimeout(valueTimeoutRef.current);
+      if (valueToTimeoutRef.current) clearTimeout(valueToTimeoutRef.current);
     };
   }, []);
 
-  const config: ColumnFilterConfig = typeof column.def.filterable === 'object' ? column.def.filterable : { type: 'number' };
-
-  const applyFilter = useCallback(
-    (op: NumberFilterValue['operator'], val: string | number, valTo?: string | number) => {
-      const numVal = typeof val === 'number' ? val : parseFloat(val);
-
-      if (isNaN(numVal) || val === '') {
-        grid.setColumnFilter(column.key, undefined);
-        return;
-      }
-
-      const filter: NumberFilterValue = {
-        type: 'number',
-        operator: op,
-        value: numVal,
-      };
-
-      if (op === 'between' && valTo !== undefined && valTo !== '') {
-        const numValTo = typeof valTo === 'number' ? valTo : parseFloat(String(valTo));
-        if (!isNaN(numValTo)) {
-          filter.valueTo = numValTo;
-        }
-      }
-
-      grid.setColumnFilter(column.key, filter);
-    },
-    [grid, column.key],
-  );
+  const config = column.filterConfig;
 
   const handleValueChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
       setLocalValue(value);
 
-      // Clear previous timeout
-      if (valueTimeoutRef.current) {
-        clearTimeout(valueTimeoutRef.current);
-      }
+      if (valueTimeoutRef.current) clearTimeout(valueTimeoutRef.current);
 
       valueTimeoutRef.current = setTimeout(() => {
-        applyFilter(operator, value, valueTo);
+        column.setNumberFilter(operator, value, valueTo);
         valueTimeoutRef.current = null;
       }, 300);
     },
-    [operator, valueTo, applyFilter],
+    [column, operator, valueTo],
   );
 
   const handleOperatorChange = useCallback(
     (op: NumberFilterValue['operator']) => {
       setOperator(op);
-      applyFilter(op, localValue, valueTo);
+      column.setNumberFilter(op, localValue, valueTo);
     },
-    [localValue, valueTo, applyFilter],
+    [column, localValue, valueTo],
   );
 
   const handleValueToChange = useCallback(
@@ -166,39 +123,34 @@ function NumberFilter<TRow>({ column, grid }: Props<TRow>) {
       const value = e.target.value;
       setValueTo(value);
 
-      // Clear previous timeout
-      if (valueToTimeoutRef.current) {
-        clearTimeout(valueToTimeoutRef.current);
-      }
+      if (valueToTimeoutRef.current) clearTimeout(valueToTimeoutRef.current);
 
       valueToTimeoutRef.current = setTimeout(() => {
-        applyFilter(operator, localValue, value);
+        column.setNumberFilter(operator, localValue, value);
         valueToTimeoutRef.current = null;
       }, 300);
     },
-    [operator, localValue, applyFilter],
+    [column, operator, localValue],
   );
 
   const handleClear = useCallback(() => {
     setLocalValue('');
     setValueTo('');
     setOperator('eq');
-    grid.setColumnFilter(column.key, undefined);
-  }, [grid, column.key]);
+    column.clearFilter();
+  }, [column]);
 
   return (
-    <Flex
-      component={`${grid.componentName}.filter.cell.input` as never}
-      ai={operator === 'between' ? 'start' : 'center'}
-      gap={1}
-      width="fit"
-    >
+    <Flex component={`${grid.componentName}.filter.cell.input` as never} ai={operator === 'between' ? 'start' : 'center'} gap={1}>
       <Dropdown<NumberFilterValue['operator']>
         value={operator}
         variant="compact"
         onChange={(val) => val && handleOperatorChange(val)}
         minWidth={6}
         hideIcon
+        b={0}
+        bgColor="transparent"
+        focus={{ outline: 0 }}
       >
         <Dropdown.Item value="eq">=</Dropdown.Item>
         <Dropdown.Item value="ne">≠</Dropdown.Item>
@@ -214,11 +166,14 @@ function NumberFilter<TRow>({ column, grid }: Props<TRow>) {
             <Textbox
               type="number"
               variant="compact"
-              placeholder={config.placeholder ?? 'From'}
+              placeholder={config?.placeholder ?? 'From'}
               value={localValue}
               onChange={handleValueChange}
               width="fit"
-              step={config.step}
+              step={config?.step}
+              b={0}
+              bgColor="transparent"
+              focus={{ outline: 0 }}
             />
             {(localValue !== '' || valueTo !== '') && (
               <Flex position="absolute" right={2} top="1/2" translateY="-1/2" cursor="pointer" props={{ onClick: handleClear }}>
@@ -236,7 +191,10 @@ function NumberFilter<TRow>({ column, grid }: Props<TRow>) {
               value={valueTo}
               onChange={handleValueToChange}
               width="fit"
-              step={config.step}
+              step={config?.step}
+              b={0}
+              bgColor="transparent"
+              focus={{ outline: 0 }}
             />
           </Flex>
         </Flex>
@@ -245,11 +203,14 @@ function NumberFilter<TRow>({ column, grid }: Props<TRow>) {
           <Textbox
             type="number"
             variant="compact"
-            placeholder={config.placeholder ?? 'Value'}
+            placeholder={config?.placeholder ?? 'Value'}
             value={localValue}
             onChange={handleValueChange}
             width="fit"
-            step={config.step}
+            step={config?.step}
+            b={0}
+            bgColor="transparent"
+            focus={{ outline: 0 }}
           />
           {localValue !== '' && (
             <Flex position="absolute" right={2} top="1/2" translateY="-1/2" cursor="pointer" props={{ onClick: handleClear }}>
@@ -265,80 +226,78 @@ function NumberFilter<TRow>({ column, grid }: Props<TRow>) {
 }
 
 /**
- * Multi-select filter with checkbox list
+ * Multi-select filter with checkbox list.
  */
 function MultiselectFilter<TRow>({ column, grid }: Props<TRow>) {
-  const currentFilter = grid.columnFilters[column.key as keyof TRow];
+  const currentFilter = column.currentFilter;
   const selectedValues = currentFilter?.type === 'multiselect' ? currentFilter.values : [];
-
-  const config: ColumnFilterConfig = typeof column.def.filterable === 'object' ? column.def.filterable : { type: 'multiselect' };
-
-  // Get options from config or compute unique values
-  const options: FilterOption[] = useMemo(() => {
-    if (config.options) {
-      return config.options;
-    }
-
-    const uniqueValues = grid.getColumnUniqueValues(column.key);
-    return uniqueValues.map((value) => ({
-      label: value === null ? '(empty)' : String(value),
-      value,
-    }));
-  }, [config.options, grid, column.key]);
+  const options = column.filterOptions;
 
   const handleChange = useCallback(
     (_value: string | number | boolean | null | undefined, values: (string | number | boolean | null)[]) => {
-      if (values.length === 0) {
-        grid.setColumnFilter(column.key, undefined);
-      } else {
-        grid.setColumnFilter(column.key, { type: 'multiselect', values });
-      }
+      column.setMultiselectFilter(values);
     },
-    [grid, column.key],
+    [column],
   );
 
   return (
-    <Dropdown<string | number | boolean | null>
-      component={`${grid.componentName}.filter.cell.input` as never}
-      multiple
-      showCheckbox
-      isSearchable
-      searchPlaceholder="Search..."
-      value={selectedValues}
-      width="fit"
-      minWidth={0}
-      onChange={handleChange}
-      variant="compact"
-    >
-      <Dropdown.Unselect>Clear</Dropdown.Unselect>
-      <Dropdown.SelectAll>Select All</Dropdown.SelectAll>
-      {options.map((option) => (
-        <Dropdown.Item<string | number | boolean | null> key={String(option.value)} value={option.value} ai="center" gap={2}>
-          {option.label}
-        </Dropdown.Item>
-      ))}
-    </Dropdown>
+    <Flex component={`${grid.componentName}.filter.cell.input` as never}>
+      <Dropdown<string | number | boolean | null>
+        multiple
+        showCheckbox
+        isSearchable
+        searchPlaceholder="Search..."
+        value={selectedValues}
+        width="fit"
+        minWidth={0}
+        bgColor="transparent"
+        onChange={handleChange}
+        variant="compact"
+        b={0}
+        focus={{ outline: 0 }}
+      >
+        <Dropdown.Display>
+          {(vals: (string | number | boolean | null)[]) => {
+            if (vals.length === 0)
+              return (
+                <Box tag="span" color="gray-400">
+                  {column.filterConfig?.placeholder ?? 'Select...'}
+                </Box>
+              );
+            if (vals.length === 1) {
+              const opt = options.find((o) => o.value === vals[0]);
+              return opt?.label ?? String(vals[0]);
+            }
+            return `${vals.length} selected`;
+          }}
+        </Dropdown.Display>
+        <Dropdown.Unselect>Clear</Dropdown.Unselect>
+        <Dropdown.SelectAll>Select All</Dropdown.SelectAll>
+        {options.map((option) => (
+          <Dropdown.Item<string | number | boolean | null> key={String(option.value)} value={option.value} ai="center" gap={2}>
+            {option.label}
+          </Dropdown.Item>
+        ))}
+      </Dropdown>
+    </Flex>
   );
 }
 
 /**
- * Main column filter component that renders the appropriate filter type
+ * Renders the appropriate filter input for the column's resolved filter type.
  */
 export default function DataGridColumnFilter<TRow>(props: Props<TRow>) {
   const { column, grid } = props;
-  const { filterable } = column.def;
+  const config = column.filterConfig;
 
-  if (!filterable) return null;
-
-  const config: ColumnFilterConfig = typeof filterable === 'object' ? filterable : { type: 'text' };
+  if (!config) return null;
 
   switch (config.type) {
-    case 'text':
-      return <TextFilter column={column} grid={grid} />;
     case 'number':
       return <NumberFilter column={column} grid={grid} />;
     case 'multiselect':
       return <MultiselectFilter column={column} grid={grid} />;
+    case 'text':
     default:
       return <TextFilter column={column} grid={grid} />;
   }

--- a/src/components/dataGrid/components/dataGridColumnGroups.tsx
+++ b/src/components/dataGrid/components/dataGridColumnGroups.tsx
@@ -21,11 +21,9 @@ export default function DataGridColumnGroups<TRow>(props: Props<TRow>) {
       <Span component={`${grid.componentName}.topBar.columnGroups.icon` as never}>
         <GroupingIcon width="100%" fill="currentColor" />
       </Span>
-      {Array.from(grid.groupColumns, (groupColumn) => {
-        const column = grid.columns.value.leafs.findOrThrow((l) => l.key === groupColumn);
-
+      {grid.groupedColumns.map((column) => {
         return (
-          <React.Fragment key={groupColumn}>
+          <React.Fragment key={column.key}>
             <ExpandIcon fill="currentColor" width="14px" height="14px" rotate={-90} />
             <Flex component={`${grid.componentName}.topBar.columnGroups.item` as never}>
               {column.header ?? column.key}

--- a/src/components/dataGrid/components/dataGridContent.tsx
+++ b/src/components/dataGrid/components/dataGridContent.tsx
@@ -26,9 +26,7 @@ export default function DataGridContent<TRow>(props: Props<TRow>) {
     });
   }, []);
 
-  const hasVisibleColumns = grid.columns.value.userVisibleLeafs.length > 0;
-
-  if (!hasVisibleColumns) {
+  if (!grid.hasVisibleColumns) {
     return <DataGridEmptyColumns grid={grid} />;
   }
 

--- a/src/components/dataGrid/components/dataGridDetailRow.tsx
+++ b/src/components/dataGrid/components/dataGridDetailRow.tsx
@@ -11,7 +11,7 @@ export default function DataGridDetailRow<TRow>(props: Props<TRow>) {
   const { grid, parentRow } = row;
   const config = grid.props.def.rowDetail!;
 
-  const isAutoHeight = row.height === 'auto';
+  const isAutoHeight = row.isAutoHeight;
 
   return (
     <Flex

--- a/src/components/dataGrid/components/dataGridDetailRow.tsx
+++ b/src/components/dataGrid/components/dataGridDetailRow.tsx
@@ -22,7 +22,14 @@ export default function DataGridDetailRow<TRow>(props: Props<TRow>) {
         height: isAutoHeight ? 'auto' : `${row.height}px`,
       }}
     >
-      <Box position="sticky" left={0} overflowX="auto" overflowY="hidden" style={{ width: `var(${grid.viewportWidthVarName})` }}>
+      <Box
+        component={`${grid.componentName}.body.detailRow.content` as never}
+        position="sticky"
+        left={0}
+        overflowX="auto"
+        overflowY="hidden"
+        style={{ width: `var(${grid.viewportWidthVarName})` }}
+      >
         {config.content(parentRow.data)}
       </Box>
     </Flex>

--- a/src/components/dataGrid/components/dataGridFilterCell.tsx
+++ b/src/components/dataGrid/components/dataGridFilterCell.tsx
@@ -1,6 +1,6 @@
 import Flex from '../../flex';
 import ColumnModel from '../models/columnModel';
-import GridModel, { EMPTY_CELL_KEY, GROUPING_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
+import GridModel from '../models/gridModel';
 import DataGridColumnFilter from './dataGridColumnFilter';
 
 interface Props<TRow> {
@@ -10,27 +10,17 @@ interface Props<TRow> {
 
 export default function DataGridFilterCell<TRow>(props: Props<TRow>) {
   const { column, grid } = props;
-  const { key, pin, left, right, isEdge, widthVarName, leftVarName, rightVarName, filterable } = column;
+  const { widthVarName, leftVarName, rightVarName, filterable } = column;
+  const { isLeftPinned, isRightPinned, isPinned, isFirstLeftPinned, isLastLeftPinned, isFirstRightPinned, isLastRightPinned } =
+    column.pinFlags.value;
 
-  const isEmptyCell = key === EMPTY_CELL_KEY;
-  const isGroupingCell = key === GROUPING_CELL_KEY;
-  const isRowNumber = key === ROW_NUMBER_CELL_KEY;
-  const isRowSelection = key === ROW_SELECTION_CELL_KEY;
-  const isSpecialCell = isEmptyCell || isGroupingCell || isRowNumber || isRowSelection;
-
-  const isLeftPinned = pin === 'LEFT';
-  const isRightPinned = pin === 'RIGHT';
-  const isPinned = isLeftPinned || isRightPinned;
-  const isFirstLeftPinned = isLeftPinned && left === 0;
-  const isLastLeftPinned = isLeftPinned && isEdge;
-  const isFirstRightPinned = isRightPinned && isEdge;
-  const isLastRightPinned = isRightPinned && right === 0;
+  const isSpecialCell = column.isGrouping || column.isRowNumber || column.isRowSelection;
 
   return (
     <Flex
       component={`${grid.componentName}.filter.cell` as never}
       variant={{ isPinned, isFirstLeftPinned, isLastLeftPinned, isFirstRightPinned, isLastRightPinned } as never}
-      px={isEmptyCell ? 0 : 2}
+      px={2}
       style={{
         width: `var(${widthVarName})`,
         left: isLeftPinned ? `var(${leftVarName})` : undefined,

--- a/src/components/dataGrid/components/dataGridFilterRow.tsx
+++ b/src/components/dataGrid/components/dataGridFilterRow.tsx
@@ -7,14 +7,10 @@ interface Props<TRow> {
 
 export default function DataGridFilterRow<TRow>(props: Props<TRow>) {
   const { grid } = props;
-  const { visibleLeafs } = grid.columns.value;
 
-  // Check if any column has filterable enabled
-  const hasFilterableColumns = visibleLeafs.some((col) => col.filterable);
+  if (!grid.filter.hasFilterableColumns) return null;
 
-  if (!hasFilterableColumns) return null;
-
-  return visibleLeafs.map((column) => <DataGridFilterCell key={column.uniqueKey} column={column} grid={grid} />);
+  return grid.columns.value.visibleLeafs.map((column) => <DataGridFilterCell key={column.uniqueKey} column={column} grid={grid} />);
 }
 
 (DataGridFilterRow as React.FunctionComponent).displayName = 'DataGridFilterRow';

--- a/src/components/dataGrid/components/dataGridGlobalFilter.tsx
+++ b/src/components/dataGrid/components/dataGridGlobalFilter.tsx
@@ -36,7 +36,7 @@ export default function DataGridGlobalFilter<TRow>(props: Props<TRow>) {
 
       // Set new timeout
       timeoutRef.current = setTimeout(() => {
-        grid.setGlobalFilter(value);
+        grid.filter.setGlobalFilter(value);
         timeoutRef.current = null;
       }, 300);
     },
@@ -45,11 +45,11 @@ export default function DataGridGlobalFilter<TRow>(props: Props<TRow>) {
 
   const handleClear = useCallback(() => {
     setLocalValue('');
-    grid.setGlobalFilter('');
+    grid.filter.setGlobalFilter('');
   }, [grid]);
 
-  const { filtered, total } = grid.filterStats;
-  const showStats = grid.hasActiveFilters && filtered !== total;
+  const { filtered, total } = grid.filter.filterStats;
+  const showStats = grid.filter.hasActiveFilters && filtered !== total;
 
   return (
     <Flex component={`${grid.componentName}.topBar.globalFilter` as never}>

--- a/src/components/dataGrid/components/dataGridGroupRow.tsx
+++ b/src/components/dataGrid/components/dataGridGroupRow.tsx
@@ -4,7 +4,6 @@ import ExpandIcon from '../../../icons/expandIcon';
 import Button from '../../button';
 import Checkbox from '../../checkbox';
 import Flex from '../../flex';
-import { EMPTY_CELL_KEY, GROUPING_CELL_KEY, ROW_DETAIL_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
 import GroupRowModel from '../models/groupRowModel';
 import DataGridCell from './dataGridCell';
 
@@ -14,11 +13,9 @@ interface Props<TRow> {
 
 export default function DataGridGroupRow<TRow>(props: Props<TRow>) {
   const { row } = props;
-  const { selected, indeterminate, cells, groupingColumn, groupingColumnGridColumn, depth, expanded } = row;
+  const { selected, indeterminate, cells, expanded } = row;
 
-  const selectAllHandler = useCallback(() => {
-    row.grid.toggleRowsSelection(row.allRows.map((x) => x.key));
-  }, []);
+  const selectAllHandler = useCallback(() => row.toggleSelectAll(), [row]);
 
   return (
     <Flex
@@ -29,55 +26,51 @@ export default function DataGridGroupRow<TRow>(props: Props<TRow>) {
       props={{ role: 'rowgroup' }}
     >
       {cells.map((cell) => {
-        const { key, pin, groupColumnWidthVarName } = cell.column;
-        const isRightPinned = pin === 'RIGHT';
+        switch (cell.cellKind) {
+          case 'grouping':
+            return (
+              <DataGridCell
+                key={cell.column.key}
+                column={cell.column}
+                style={{ width: cell.widthVar, right: cell.isRightPinned ? '0' : undefined }}
+                br={cell.hasGroupingBorder ? 1 : undefined}
+                gridColumn={cell.gridColumnSpan}
+                pl={cell.depthPadding}
+                overflow="auto"
+              >
+                <Box textWrap="nowrap" px={3}>
+                  <Button
+                    component={`${row.grid.componentName}.body.groupRow.expandButton` as never}
+                    clean
+                    onClick={() => row.toggleRow()}
+                    cursor="pointer"
+                    display="flex"
+                    gap={1}
+                    ai="center"
+                  >
+                    <ExpandIcon fill="currentColor" width="14px" height="14px" rotate={expanded ? 0 : -90} />
+                    {cell.value}
+                  </Button>
+                </Box>
+              </DataGridCell>
+            );
 
-        if (key === GROUPING_CELL_KEY) {
-          return (
-            <DataGridCell
-              key={key}
-              column={cell.column}
-              style={{
-                width: `var(${groupColumnWidthVarName})`,
-                right: isRightPinned ? '0' : undefined,
-              }}
-              br={groupingColumn.pin === 'LEFT' ? 1 : undefined}
-              gridColumn={groupingColumnGridColumn}
-              pl={4 * depth}
-              overflow="auto"
-            >
-              <Box textWrap="nowrap" px={3}>
-                <Button
-                  component={`${row.grid.componentName}.body.groupRow.expandButton` as never}
-                  clean
-                  onClick={() => row.toggleRow()}
-                  cursor="pointer"
-                  display="flex"
-                  gap={1}
-                  ai="center"
-                >
-                  <ExpandIcon fill="currentColor" width="14px" height="14px" rotate={expanded ? 0 : -90} />
-                  {cell.value}
-                </Button>
-              </Box>
-            </DataGridCell>
-          );
-        }
+          case 'selection':
+            return (
+              <DataGridCell key={cell.column.key} column={cell.column}>
+                <Checkbox variant="datagrid" m={1} checked={selected} indeterminate={indeterminate} onChange={selectAllHandler} />
+              </DataGridCell>
+            );
 
-        if (key === ROW_SELECTION_CELL_KEY) {
-          return (
-            <DataGridCell key={key} column={cell.column}>
-              <Checkbox variant="datagrid" m={1} checked={selected} indeterminate={indeterminate} onChange={selectAllHandler} />
-            </DataGridCell>
-          );
-        }
+          case 'spacer':
+            return (
+              <DataGridCell key={cell.column.key} column={cell.column} px={cell.column.isRowNumber ? 3 : undefined}>
+                {cell.value}
+              </DataGridCell>
+            );
 
-        if (pin !== groupingColumn.pin || key === ROW_NUMBER_CELL_KEY || key === EMPTY_CELL_KEY || key === ROW_DETAIL_CELL_KEY) {
-          return (
-            <DataGridCell key={key} column={cell.column} px={key === ROW_NUMBER_CELL_KEY ? 3 : undefined}>
-              {cell.value}
-            </DataGridCell>
-          );
+          default:
+            return null;
         }
       })}
     </Flex>

--- a/src/components/dataGrid/components/dataGridHeaderCell.tsx
+++ b/src/components/dataGrid/components/dataGridHeaderCell.tsx
@@ -1,10 +1,9 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import Box from '../../../box';
 import SortIcon from '../../../icons/sortIcon';
 import Checkbox from '../../checkbox';
 import Flex from '../../flex';
 import ColumnModel from '../models/columnModel';
-import { EMPTY_CELL_KEY, GROUPING_CELL_KEY, ROW_DETAIL_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
 import DataGridHeaderCellContextMenu from './dataGridHeaderCellContextMenu';
 import DataGridHeaderCellResizer from './dataGridHeaderCellResizer';
 
@@ -14,120 +13,62 @@ interface Props<TRow> {
 
 export default function DataGridHeaderCell<TRow>(props: Props<TRow>) {
   const { column } = props;
-  const {
-    key,
-    pin,
-    left,
-    right,
-    isEdge,
-    isLeaf,
-    leafs,
-    grid,
-    header,
-    gridRows,
-    widthVarName,
-    leftVarName,
-    rightVarName,
-    inlineWidth,
-    isFirstLeaf,
-    isLastLeaf,
-  } = column;
-
-  const isEmptyCell = key === EMPTY_CELL_KEY;
-  const isGroupingCell = key === GROUPING_CELL_KEY;
-  const isRowNumber = key === ROW_NUMBER_CELL_KEY;
-  const isRowSelection = key === ROW_SELECTION_CELL_KEY;
-  const isRowDetailCell = key === ROW_DETAIL_CELL_KEY;
-
-  const isLeftPinned = pin === 'LEFT';
-  const isRightPinned = pin === 'RIGHT';
-  const isPinned = isLeftPinned || pin === 'RIGHT';
-  const isFirstLeftPinned = isLeftPinned && left === 0;
-  const isLastLeftPinned = isLeftPinned && isEdge;
-  const isFirstRightPinned = isRightPinned && isEdge;
-  const isLastRightPinned = isRightPinned && right === 0;
-  const isSortable = isLeaf && !isEmptyCell && !isRowNumber && !isRowSelection && !isRowDetailCell && column.sortable;
-
-  const gridColumn = isLeaf ? 1 : leafs.length;
-
-  const showResizer = !isRowNumber && !isRowSelection && !isRowDetailCell && column.resizable;
-  const showContextMenu = !isRowNumber && !isRowSelection && !isRowDetailCell && column.showContextMenu;
-
-  const pl = isRowSelection ? undefined : column.align === 'right' ? 10 : 3;
-  const pr = isRowSelection ? undefined : column.align === 'center' ? 3 : undefined;
+  const { grid } = column;
+  const { isLeftPinned, isRightPinned } = column.pinFlags.value;
+  const headerCell = column.headerCell;
+  const { isSortable, showResizer, showContextMenu, paddingLeft, paddingRight } = headerCell;
 
   const toggleSelectAll = useCallback(() => {
     grid.toggleSelectAllRows();
-  }, []);
+  }, [grid]);
 
-  const value = useMemo(() => {
-    if (isRowNumber) return null;
-    if (isRowSelection) {
-      const checked = grid.selectedRows.size === grid.props.data.length;
-      const indeterminate = !checked && grid.selectedRows.size > 0;
-
-      return <Checkbox variant="datagrid" m={1} indeterminate={indeterminate} checked={checked} onChange={toggleSelectAll} />;
-    }
-    if (isGroupingCell) {
-      if (grid.groupColumns.size === 1) {
-        const col = grid.columns.value.leafs.findOrThrow((l) => l.key === grid.groupColumns.values().next().value!);
-
-        return col.header ?? col.key;
-      }
-
-      return 'Group';
-    }
-
-    return header ?? key;
-  }, [grid.groupColumns, grid.selectedRows, toggleSelectAll]);
+  // Row-selection header renders a select-all checkbox; everything else renders its label.
+  const value = column.isRowSelection ? (
+    <Checkbox
+      variant="datagrid"
+      m={1}
+      indeterminate={grid.someRowsSelected && !grid.allRowsSelected}
+      checked={grid.allRowsSelected}
+      onChange={toggleSelectAll}
+    />
+  ) : (
+    headerCell.label
+  );
 
   return (
     <Flex
       props={{ role: 'columnheader' }}
       className="header-cell"
       component={`${grid.componentName}.header.cell` as never}
-      variant={
-        {
-          isPinned,
-          isFirstLeftPinned,
-          isLastLeftPinned,
-          isFirstRightPinned,
-          isLastRightPinned,
-          isSortable,
-          isRowNumber,
-          isFirstLeaf,
-          isLastLeaf,
-          isEmptyCell,
-        } as never
-      }
-      gridRow={gridRows}
-      gridColumn={gridColumn}
+      variant={headerCell.variant as never}
+      gridRow={column.gridRows}
+      gridColumn={headerCell.gridColumn}
       style={{
-        width: `var(${widthVarName})`,
-        left: isLeftPinned ? `var(${leftVarName})` : undefined,
-        right: isRightPinned ? `var(${rightVarName})` : undefined,
+        width: `var(${column.widthVarName})`,
+        left: isLeftPinned ? `var(${column.leftVarName})` : undefined,
+        right: isRightPinned ? `var(${column.rightVarName})` : undefined,
       }}
     >
-      {!isEmptyCell && (
+      {
         <>
           <Flex width="fit" height="fit" jc={column.align} props={{ onClick: isSortable ? () => column.sortColumn() : undefined }}>
             <Flex
               overflow="hidden"
-              position={isLeaf ? undefined : 'sticky'}
+              position={column.isLeaf ? undefined : 'sticky'}
               ai="center"
               transition="none"
-              pl={pl}
-              pr={pr}
+              pl={paddingLeft}
+              pr={paddingRight}
               style={{
-                left: !pin ? `var(${grid.leftEdgeVarName})` : undefined,
+                left: !column.pin ? `var(${grid.leftEdgeVarName})` : undefined,
               }}
             >
               <Box overflow="hidden" textOverflow="ellipsis" textWrap="nowrap">
                 {value}
               </Box>
-              {key === grid.sortColumn && (
-                <Box pl={(inlineWidth ?? 0) < 58 ? 0 : 2}>
-                  <SortIcon width="16px" rotate={grid.sortDirection === 'ASC' ? 0 : 180} fill="currentColor" />
+              {headerCell.isSorted && (
+                <Box pl={(column.inlineWidth ?? 0) < 58 ? 0 : 2}>
+                  <SortIcon width="16px" rotate={headerCell.sortDirection === 'ASC' ? 0 : 180} fill="currentColor" />
                 </Box>
               )}
               {showContextMenu && <Box minWidth={column.align === 'right' ? 4 : 10} />}
@@ -138,7 +79,7 @@ export default function DataGridHeaderCell<TRow>(props: Props<TRow>) {
 
           {showContextMenu && <DataGridHeaderCellContextMenu column={column} />}
         </>
-      )}
+      }
     </Flex>
   );
 }

--- a/src/components/dataGrid/components/dataGridHeaderCellContextMenu.tsx
+++ b/src/components/dataGrid/components/dataGridHeaderCellContextMenu.tsx
@@ -9,7 +9,6 @@ import Flex from '../../flex';
 import { Span } from '../../semantics';
 import Tooltip from '../../tooltip';
 import ColumnModel from '../models/columnModel';
-import { EMPTY_CELL_KEY, GROUPING_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
 
 interface Props<TRow> {
   column: ColumnModel<TRow>;
@@ -17,48 +16,22 @@ interface Props<TRow> {
 
 export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) {
   const { column } = props;
-  const { key, pin, left, right, isEdge, isLeaf, align, header, grid } = column;
+  const { grid, align, header, key } = column;
+  const hc = column.headerCell;
 
   const [isOpen, setOpen, refToUse] = useVisibility({ hideOnScroll: true, event: 'mousedown' });
   const [tooltipPosition, setTooltipPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
   const openLeft = useMemo(() => tooltipPosition.left > window.innerWidth / 2, [tooltipPosition.left]);
 
-  const { sort: showSort, pin: showPin, group: showGroup } = column.contextMenuSections;
-
-  const isSortAscAvailable = showSort && isLeaf && column.sortable && (grid.sortColumn !== key || grid.sortDirection === 'DESC');
-  const isSortDescAvailable = showSort && isLeaf && column.sortable && (grid.sortColumn !== key || grid.sortDirection === 'ASC');
-  const isClearSortAvailable = showSort && isLeaf && column.sortable && grid.sortColumn === key;
-  const isPinLeftAvailable = showPin && pin !== 'LEFT';
-  const isPinRightAvailable = showPin && pin !== 'RIGHT';
-  const isUnpinAvailable = showPin && !!pin;
-  const isGroupByAvailable = showGroup && isLeaf && key !== GROUPING_CELL_KEY;
-  const isUnGroupByAvailable = showGroup && isLeaf && key === GROUPING_CELL_KEY;
-
-  const isSortingAvailable = isSortAscAvailable || isSortDescAvailable || isClearSortAvailable;
-  const isPiningAvailable = isPinLeftAvailable || isPinRightAvailable || isUnpinAvailable;
-
   const positionLeft = align === 'right' ? 2 : undefined;
-  const positionRight = align === 'right' ? undefined : pin === 'RIGHT' ? 2.5 : 4;
-
-  const isEmptyCell = key === EMPTY_CELL_KEY;
-  const isRowNumber = key === ROW_NUMBER_CELL_KEY;
-  const isRowSelection = key === ROW_SELECTION_CELL_KEY;
-
-  const isLeftPinned = pin === 'LEFT';
-  const isRightPinned = pin === 'RIGHT';
-  const isPinned = isLeftPinned || pin === 'RIGHT';
-  const isFirstLeftPinned = isLeftPinned && left === 0;
-  const isLastLeftPinned = isLeftPinned && isEdge;
-  const isFirstRightPinned = isRightPinned && isEdge;
-  const isLastRightPinned = isRightPinned && right === 0;
-  const isSortable = isLeaf && !isEmptyCell && !isRowNumber && !isRowSelection && column.sortable;
+  const positionRight = align === 'right' ? undefined : column.pin === 'RIGHT' ? 2.5 : 4;
 
   return (
     <Flex position="absolute" left={positionLeft} right={positionRight} top="1/2" translateY={-3} ai="center">
       <Button
         component={`${grid.componentName}.header.cell.contextMenu` as never}
         onClick={() => setOpen(!isOpen)}
-        variant={{ isPinned, isFirstLeftPinned, isLastLeftPinned, isFirstRightPinned, isLastRightPinned, isSortable, isRowNumber } as never}
+        variant={hc.contextMenuButtonVariant as never}
       >
         <Span component={`${grid.componentName}.header.cell.contextMenu.icon` as never}>
           <DotsIcon fill="currentColor" />
@@ -71,7 +44,7 @@ export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) 
             adjustTranslateX={openLeft ? '-100%' : '-21px'}
             adjustTranslateY="16px"
           >
-            {isSortAscAvailable && (
+            {hc.canSortAsc && (
               <Button
                 component={`${grid.componentName}.header.cell.contextMenu.tooltip.item` as never}
                 onClick={() => column.sortColumn('ASC')}
@@ -82,7 +55,7 @@ export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) 
                 Sort Ascending
               </Button>
             )}
-            {isSortDescAvailable && (
+            {hc.canSortDesc && (
               <Button
                 component={`${grid.componentName}.header.cell.contextMenu.tooltip.item` as never}
                 onClick={() => column.sortColumn('DESC')}
@@ -93,7 +66,7 @@ export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) 
                 Sort Descending
               </Button>
             )}
-            {isClearSortAvailable && (
+            {hc.canClearSort && (
               <Button
                 component={`${grid.componentName}.header.cell.contextMenu.tooltip.item` as never}
                 onClick={() => column.sortColumn(undefined)}
@@ -102,7 +75,7 @@ export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) 
                 Clear Sort
               </Button>
             )}
-            {isSortingAvailable && (isPiningAvailable || isGroupByAvailable || isUnGroupByAvailable) && (
+            {hc.hasSortSection && (hc.hasPinSection || hc.hasGroupSection) && (
               <Box
                 bb={1}
                 my={2}
@@ -110,7 +83,7 @@ export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) 
                 component={`${grid.componentName}.header.cell.contextMenu.tooltip.item.separator` as never}
               />
             )}
-            {isPinLeftAvailable && (
+            {hc.canPinLeft && (
               <Button
                 component={`${grid.componentName}.header.cell.contextMenu.tooltip.item` as never}
                 onClick={() => column.pinColumn('LEFT')}
@@ -121,7 +94,7 @@ export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) 
                 Pin Left
               </Button>
             )}
-            {isPinRightAvailable && (
+            {hc.canPinRight && (
               <Button
                 component={`${grid.componentName}.header.cell.contextMenu.tooltip.item` as never}
                 onClick={() => column.pinColumn('RIGHT')}
@@ -132,16 +105,16 @@ export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) 
                 Pin Right
               </Button>
             )}
-            {isUnpinAvailable && (
+            {hc.canUnpin && (
               <Button component={`${grid.componentName}.header.cell.contextMenu.tooltip.item` as never} onClick={() => column.pinColumn()}>
                 <Box width={4} />
                 Unpin
               </Button>
             )}
-            {isSortingAvailable && isPiningAvailable && (isGroupByAvailable || isUnGroupByAvailable) && (
+            {hc.hasSortSection && hc.hasPinSection && hc.hasGroupSection && (
               <Box component={`${grid.componentName}.header.cell.contextMenu.tooltip.item.separator` as never} />
             )}
-            {isGroupByAvailable && (
+            {hc.canGroupBy && (
               <Button component={`${grid.componentName}.header.cell.contextMenu.tooltip.item` as never} onClick={column.toggleGrouping}>
                 <Span component={`${grid.componentName}.header.cell.contextMenu.tooltip.item.icon` as never}>
                   <GroupingIcon width="100%" fill="currentColor" />
@@ -149,7 +122,7 @@ export default function DataGridHeaderCellContextMenu<TRow>(props: Props<TRow>) 
                 <Box textWrap="nowrap">Group by {header ?? key}</Box>
               </Button>
             )}
-            {isUnGroupByAvailable && (
+            {hc.canUnGroupAll && (
               <Button component={`${grid.componentName}.header.cell.contextMenu.tooltip.item` as never} onClick={grid.unGroupAll}>
                 <Span component={`${grid.componentName}.header.cell.contextMenu.tooltip.item.icon` as never}>
                   <GroupingIcon width="100%" fill="currentColor" />

--- a/src/components/dataGrid/components/dataGridHeaderCellResizer.tsx
+++ b/src/components/dataGrid/components/dataGridHeaderCellResizer.tsx
@@ -1,4 +1,6 @@
+import { useCallback } from 'react';
 import Box from '../../../box';
+import FnUtils from '../../../utils/fn/fnUtils';
 import Flex from '../../flex';
 import ColumnModel from '../models/columnModel';
 
@@ -6,9 +8,33 @@ interface Props<TRow> {
   column: ColumnModel<TRow>;
 }
 
+const pageXOf = (e: MouseEvent | TouchEvent): number => ('touches' in e ? (e.touches[0]?.pageX ?? 0) : e.pageX);
+
 export default function DataGridHeaderCellResizer<TRow>(props: Props<TRow>) {
   const { column } = props;
   const resizerStyle = column.grid.resizerStyle;
+
+  // The model owns the resize math (beginResize/resizeTo/endResize); this adapter
+  // only wires the DOM drag and throttles pointer moves.
+  const startResize = useCallback(
+    (e: React.MouseEvent | React.TouchEvent) => {
+      column.beginResize(pageXOf(e.nativeEvent));
+
+      const controller = new AbortController();
+      const { signal } = controller;
+      const move = FnUtils.throttle((ev: MouseEvent | TouchEvent) => column.resizeTo(pageXOf(ev)), 40);
+      const end = () => {
+        controller.abort();
+        column.endResize();
+      };
+
+      window.addEventListener('mousemove', move, { signal });
+      window.addEventListener('touchmove', move, { signal });
+      window.addEventListener('mouseup', end, { signal });
+      window.addEventListener('touchend', end, { signal });
+    },
+    [column],
+  );
 
   return (
     <Flex
@@ -25,7 +51,7 @@ export default function DataGridHeaderCellResizer<TRow>(props: Props<TRow>) {
         mt={-6}
         className="resizer"
         height="fit"
-        props={{ onMouseDown: column.resizeColumn, onTouchStart: column.resizeColumn }}
+        props={{ onMouseDown: startResize, onTouchStart: startResize }}
       >
         <Box
           component={`${column.grid.componentName}.header.cell.resizer` as never}

--- a/src/components/dataGrid/components/dataGridPagination.tsx
+++ b/src/components/dataGrid/components/dataGridPagination.tsx
@@ -12,38 +12,37 @@ interface Props<TRow> {
 
 export default function DataGridPagination<TRow>(props: Props<TRow>) {
   const { grid } = props;
-  const state = grid.paginationState;
+  const { pagination } = grid;
+  const state = pagination.state;
 
-  const page = state?.page ?? 1;
-  const totalPages = state?.totalPages ?? 1;
-  const isFirst = page <= 1;
-  const isLast = page >= totalPages;
-
-  const goFirst = useCallback(() => !isFirst && grid.changePage(1), [grid, isFirst]);
-  const goPrev = useCallback(() => !isFirst && grid.changePage(page - 1), [grid, page, isFirst]);
-  const goNext = useCallback(() => !isLast && grid.changePage(page + 1), [grid, page, isLast]);
-  const goLast = useCallback(() => !isLast && grid.changePage(totalPages), [grid, totalPages, isLast]);
+  const goFirst = useCallback(() => pagination.firstPage(), [pagination]);
+  const goPrev = useCallback(() => pagination.prevPage(), [pagination]);
+  const goNext = useCallback(() => pagination.nextPage(), [pagination]);
+  const goLast = useCallback(() => pagination.lastPage(), [pagination]);
 
   if (!state) return null;
 
+  const { canGoPrev, canGoNext, totalPages } = pagination;
+
   return (
     <Flex component={`${grid.componentName}.bottomBar.pagination` as never} gap={0.5} ai="center">
-      <PaginationButton componentName={grid.componentName} onClick={goFirst} disabled={isFirst}>
+      <PageSizeSelector grid={grid} pageSize={state.pageSize} />
+      <PaginationButton componentName={grid.componentName} onClick={goFirst} disabled={!canGoPrev}>
         <ChevronDoubleLeft />
       </PaginationButton>
-      <PaginationButton componentName={grid.componentName} onClick={goPrev} disabled={isFirst}>
+      <PaginationButton componentName={grid.componentName} onClick={goPrev} disabled={!canGoPrev}>
         <ChevronLeft />
       </PaginationButton>
       <Flex ai="center" gap={1.5} px={2} userSelect="none">
-        <PageJumpInput grid={grid} page={page} totalPages={totalPages} />
+        <PageJumpInput grid={grid} page={state.page} totalPages={totalPages} />
         <Box component={`${grid.componentName}.bottomBar.pagination.info` as never} fontSize={12} opacity={0.7}>
           of {totalPages}
         </Box>
       </Flex>
-      <PaginationButton componentName={grid.componentName} onClick={goNext} disabled={isLast}>
+      <PaginationButton componentName={grid.componentName} onClick={goNext} disabled={!canGoNext}>
         <ChevronRight />
       </PaginationButton>
-      <PaginationButton componentName={grid.componentName} onClick={goLast} disabled={isLast}>
+      <PaginationButton componentName={grid.componentName} onClick={goLast} disabled={!canGoNext}>
         <ChevronDoubleRight />
       </PaginationButton>
     </Flex>
@@ -51,6 +50,33 @@ export default function DataGridPagination<TRow>(props: Props<TRow>) {
 }
 
 (DataGridPagination as React.FunctionComponent).displayName = 'DataGridPagination';
+
+function PageSizeSelector<TRow>({ grid, pageSize }: { grid: GridModel<TRow>; pageSize: number }) {
+  const options = grid.pagination.pageSizeOptions;
+  if (!options || options.length === 0) return null;
+
+  return (
+    <Flex ai="center" gap={1} mr={1}>
+      <Box
+        component={`${grid.componentName}.bottomBar.pagination.pageSize` as never}
+        tag="select"
+        fontSize={12}
+        borderRadius={4}
+        cursor="pointer"
+        props={{
+          value: pageSize,
+          onChange: (e: React.ChangeEvent<HTMLSelectElement>) => grid.pagination.changePageSize(Number(e.target.value)),
+        }}
+      >
+        {options.map((size) => (
+          <option key={size} value={size}>
+            {size} / page
+          </option>
+        ))}
+      </Box>
+    </Flex>
+  );
+}
 
 function PageJumpInput<TRow>({ grid, page, totalPages }: { grid: GridModel<TRow>; page: number; totalPages: number }) {
   const [value, setValue] = useState(String(page));
@@ -60,15 +86,9 @@ function PageJumpInput<TRow>({ grid, page, totalPages }: { grid: GridModel<TRow>
   }, [page]);
 
   const commit = useCallback(() => {
-    const n = parseInt(value, 10);
-    if (!isNaN(n)) {
-      const clamped = Math.max(1, Math.min(n, totalPages));
-      grid.changePage(clamped);
-      setValue(String(clamped));
-    } else {
-      setValue(String(page));
-    }
-  }, [grid, page, totalPages, value]);
+    grid.pagination.jumpToPage(value);
+    setValue(String(grid.pagination.page));
+  }, [grid, value]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/dataGrid/components/dataGridPagination.tsx
+++ b/src/components/dataGrid/components/dataGridPagination.tsx
@@ -1,8 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Box from '../../../box';
 import BaseSvg from '../../baseSvg';
 import Button from '../../button';
 import Flex from '../../flex';
+import Textbox from '../../textbox';
 import GridModel from '../models/gridModel';
 
 interface Props<TRow> {
@@ -33,9 +34,12 @@ export default function DataGridPagination<TRow>(props: Props<TRow>) {
       <PaginationButton componentName={grid.componentName} onClick={goPrev} disabled={isFirst}>
         <ChevronLeft />
       </PaginationButton>
-      <Box component={`${grid.componentName}.bottomBar.pagination.info` as never} fontSize={12} px={3} userSelect="none">
-        {page} of {totalPages}
-      </Box>
+      <Flex ai="center" gap={1.5} px={2} userSelect="none">
+        <PageJumpInput grid={grid} page={page} totalPages={totalPages} />
+        <Box component={`${grid.componentName}.bottomBar.pagination.info` as never} fontSize={12} opacity={0.7}>
+          of {totalPages}
+        </Box>
+      </Flex>
       <PaginationButton componentName={grid.componentName} onClick={goNext} disabled={isLast}>
         <ChevronRight />
       </PaginationButton>
@@ -47,6 +51,45 @@ export default function DataGridPagination<TRow>(props: Props<TRow>) {
 }
 
 (DataGridPagination as React.FunctionComponent).displayName = 'DataGridPagination';
+
+function PageJumpInput<TRow>({ grid, page, totalPages }: { grid: GridModel<TRow>; page: number; totalPages: number }) {
+  const [value, setValue] = useState(String(page));
+
+  useEffect(() => {
+    setValue(String(page));
+  }, [page]);
+
+  const commit = useCallback(() => {
+    const n = parseInt(value, 10);
+    if (!isNaN(n)) {
+      const clamped = Math.max(1, Math.min(n, totalPages));
+      grid.changePage(clamped);
+      setValue(String(clamped));
+    } else {
+      setValue(String(page));
+    }
+  }, [grid, page, totalPages, value]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') commit();
+      else if (e.key === 'Escape') setValue(String(page));
+    },
+    [commit, page],
+  );
+
+  return (
+    <Textbox
+      type="number"
+      variant="compact"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      textAlign="center"
+      fontSize={12}
+      props={{ onKeyDown: handleKeyDown, onBlur: commit, min: 1, max: totalPages }}
+    />
+  );
+}
 
 function PaginationButton(props: { componentName: string; onClick: () => void; disabled: boolean; children: React.ReactNode }) {
   const { componentName, onClick, disabled, children } = props;

--- a/src/components/dataGrid/components/dataGridRow.tsx
+++ b/src/components/dataGrid/components/dataGridRow.tsx
@@ -26,8 +26,14 @@ export default function DataGridRow<TRow>(props: Props<TRow>) {
       props={{ role: 'row', onClick: expandOnRowClick ? handleRowClick : undefined }}
       cursor={expandOnRowClick ? 'pointer' : undefined}
     >
-      {row.cells.map((cell) => (
-        <DataGridCell key={cell.column.key} column={cell.column}>
+      {row.cells.map((cell, index) => (
+        <DataGridCell
+          key={cell.column.key}
+          column={cell.column}
+          isExpanded={row.expanded}
+          isFirstInRow={index === 0}
+          isLastInRow={index === row.cells.length - 1}
+        >
           {cell.column.Cell ? <cell.column.Cell cell={cell} /> : <DataGridCellText cell={cell} />}
         </DataGridCell>
       ))}

--- a/src/components/dataGrid/components/dataGridRow.tsx
+++ b/src/components/dataGrid/components/dataGridRow.tsx
@@ -10,12 +10,11 @@ interface Props<TRow> {
 
 export default function DataGridRow<TRow>(props: Props<TRow>) {
   const { row } = props;
-  const { selected } = row;
-  const expandOnRowClick = row.grid.props.def.rowDetail?.expandOnRowClick;
+  const { selected, expandOnRowClick } = row;
 
   const handleRowClick = useCallback(() => {
-    row.grid.toggleDetailRow(row.key);
-  }, [row.grid, row.key]);
+    row.toggleDetail();
+  }, [row]);
 
   return (
     <Flex

--- a/src/components/dataGrid/components/dataGridTopBar.tsx
+++ b/src/components/dataGrid/components/dataGridTopBar.tsx
@@ -14,25 +14,25 @@ export default function DataGridTopBar<TRow>(props: Props<TRow>) {
   const { title, topBarContent, globalFilter } = grid.props.def;
 
   return (
-    <Flex component={`${grid.componentName}.topBar` as never} position="relative" ai="center" jc="space-between" gap={4} flexWrap="wrap">
-      {/* Left section: Title and grouping context */}
-      <Flex ai="center" gap={3} flexWrap="wrap" minWidth={0}>
-        <DataGridTopBarContextMenu grid={grid} />
-        {title && (
-          <Box fontWeight={600} fontSize={16} color="gray-800" theme={{ dark: { color: 'gray-100' } }}>
-            {title}
-          </Box>
-        )}
+    <Flex component={`${grid.componentName}.topBar` as never} position="relative" d="column" gap={3}>
+      {/* Row 1: Title/context menu on the left, global filter pinned to the right */}
+      <Flex ai="center" jc="space-between" gap={4} flexWrap="wrap" width="fit">
+        <Flex ai="center" gap={3} flexWrap="wrap" minWidth={0}>
+          <DataGridTopBarContextMenu grid={grid} />
+          {title && (
+            <Box fontWeight={600} fontSize={16} color="gray-800" theme={{ dark: { color: 'gray-100' } }}>
+              {title}
+            </Box>
+          )}
 
-        <DataGridColumnGroups grid={grid} />
-      </Flex>
-
-      {/* Right section: Actions */}
-      <Flex ai="center" gap={3} flexWrap="wrap" jc="flex-end" minWidth={0}>
-        {topBarContent && <Box>{topBarContent}</Box>}
+          <DataGridColumnGroups grid={grid} />
+        </Flex>
 
         {globalFilter && <DataGridGlobalFilter grid={grid} />}
       </Flex>
+
+      {/* Row 2: Custom top bar content spans the full topbar width */}
+      {topBarContent && <Box width="fit">{topBarContent}</Box>}
     </Flex>
   );
 }

--- a/src/components/dataGrid/components/dataGridTopBarContextMenu.tsx
+++ b/src/components/dataGrid/components/dataGridTopBarContextMenu.tsx
@@ -1,9 +1,8 @@
-import { useMemo } from 'react';
 import Box from '../../../box';
 import BaseSvg from '../../baseSvg';
 import Dropdown from '../../dropdown';
 import Flex from '../../flex';
-import GridModel, { EMPTY_CELL_KEY, GROUPING_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from '../models/gridModel';
+import GridModel from '../models/gridModel';
 
 interface Props<TRow> {
   grid: GridModel<TRow>;
@@ -11,34 +10,11 @@ interface Props<TRow> {
 
 export default function DataGridTopBarContextMenu<TRow>(props: Props<TRow>) {
   const { grid } = props;
-
-  const leafsToHide = useMemo(
-    () =>
-      grid.columns.value.leafs.filter(
-        (l) => ![EMPTY_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY, GROUPING_CELL_KEY].includes(l.key),
-      ),
-    [grid.columns.value.leafs],
-  );
-
-  const columnEntries = leafsToHide.map((leaf) => ({
-    id: String(leaf.key),
-    label: leaf.header ?? leaf.key,
-    leaf,
-  }));
-
-  const selectedEntries = columnEntries.filter((entry) => entry.leaf.isVisible).map((entry) => entry.id);
-  const totalColumns = columnEntries.length;
-  const hiddenCount = totalColumns - selectedEntries.length;
-  const hasHidden = hiddenCount > 0;
+  const { columnVisibility } = grid;
+  const { entries, selectedIds, total, hasHidden } = columnVisibility;
 
   const handleChange = (_value: string | undefined, values: string[]) => {
-    const nextValues = new Set(values);
-    columnEntries.forEach((entry) => {
-      const shouldBeVisible = nextValues.has(entry.id);
-      if (entry.leaf.isVisible !== shouldBeVisible) {
-        entry.leaf.toggleVisibility();
-      }
-    });
+    columnVisibility.setVisibility(values);
   };
 
   return (
@@ -48,9 +24,9 @@ export default function DataGridTopBarContextMenu<TRow>(props: Props<TRow>) {
       showCheckbox
       hideIcon
       variant="compact"
-      value={selectedEntries}
+      value={selectedIds}
       onChange={handleChange}
-      isSearchable={columnEntries.length > 6}
+      isSearchable={entries.length > 6}
       searchPlaceholder="Search columns..."
       display="inline-flex"
     >
@@ -85,7 +61,7 @@ export default function DataGridTopBarContextMenu<TRow>(props: Props<TRow>) {
                     },
                   }}
                 >
-                  {selected.length}/{totalColumns}
+                  {selected.length}/{total}
                 </Box>
               )}
             </Flex>
@@ -96,7 +72,7 @@ export default function DataGridTopBarContextMenu<TRow>(props: Props<TRow>) {
       <Dropdown.SelectAll>Show All</Dropdown.SelectAll>
       <Dropdown.Unselect>Hide All</Dropdown.Unselect>
 
-      {columnEntries.map((entry) => (
+      {entries.map((entry) => (
         <Dropdown.Item<string> key={entry.id} value={entry.id} textWrap="nowrap">
           {entry.label}
         </Dropdown.Item>

--- a/src/components/dataGrid/contracts/dataGridContract.ts
+++ b/src/components/dataGrid/contracts/dataGridContract.ts
@@ -18,6 +18,8 @@ export interface PaginationConfig {
   totalCount: number;
   /** Page size override. If omitted, defaults to visibleRowsCount (or 10). */
   pageSize?: number;
+  /** Options shown in the page size selector dropdown. If omitted, no selector is shown. */
+  pageSizeOptions?: number[];
 }
 
 // ========== Server State ==========
@@ -189,6 +191,10 @@ export interface DataGridProps<TRow> {
   page?: number;
   /** Callback when page changes. Receives page (1-indexed) and pageSize. */
   onPageChange?: (page: number, pageSize: number) => void;
+  /** Controlled page size. Used with pagination and pageSizeOptions. */
+  pageSize?: number;
+  /** Callback when the user changes the page size. */
+  onPageSizeChange?: (pageSize: number) => void;
   /** Callback when sort changes. For server-side sorting with pagination. */
   onSortChange?: (columnKey: Key | undefined, direction: SortDirection | undefined) => void;
   /** Fires on any server-relevant state change (page, sort, filter). Provides full state snapshot for API calls. */

--- a/src/components/dataGrid/models/cellModel.ts
+++ b/src/components/dataGrid/models/cellModel.ts
@@ -1,5 +1,5 @@
 import ColumnModel from './columnModel';
-import GridModel, { ROW_NUMBER_CELL_KEY } from './gridModel';
+import GridModel from './gridModel';
 import RowModel from './rowModel';
 
 export default class CellModel<TRow> {
@@ -10,8 +10,26 @@ export default class CellModel<TRow> {
   ) {}
 
   public get value() {
-    if (this.column.key === ROW_NUMBER_CELL_KEY) return this.row.rowIndex + 1;
+    if (this.column.isRowNumber) return this.row.rowIndex + 1;
 
     return this.row.data[this.column.key as keyof TRow];
   }
+
+  public get expanded(): boolean {
+    return this.row.expanded;
+  }
+
+  public get selected(): boolean {
+    return this.row.selected;
+  }
+
+  /** Toggle this row's detail panel (used by the row-detail expand cell). */
+  public toggleDetail = (): void => {
+    this.grid.toggleDetailRow(this.row.key);
+  };
+
+  /** Toggle this row's selection (used by the row-selection checkbox cell). */
+  public toggleSelection = (): void => {
+    this.grid.toggleRowSelection(this.row.key);
+  };
 }

--- a/src/components/dataGrid/models/columnModel.kind.test.ts
+++ b/src/components/dataGrid/models/columnModel.kind.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { ignoreLogs } from '../../../../dev/tests';
+import { GridDefinition } from '../contracts/dataGridContract';
+import GridModel, { ROW_DETAIL_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from './gridModel';
+
+interface Person {
+  firstName: string;
+  age: number;
+  country: string;
+}
+
+const data: Person[] = [
+  { firstName: 'John', age: 20, country: 'USA' },
+  { firstName: 'Jane', age: 22, country: 'UK' },
+  { firstName: 'Bob', age: 20, country: 'USA' },
+];
+
+function getGrid(def?: Partial<GridDefinition<Person>>) {
+  return new GridModel<Person>({ data, def: { columns: [{ key: 'firstName' }, { key: 'age' }, { key: 'country' }], ...def } });
+}
+
+const leaf = (grid: GridModel<Person>, key: string | number) => grid.columns.value.leafs.findOrThrow((c) => c.key === key);
+
+describe('ColumnModel kind + layout', () => {
+  ignoreLogs();
+
+  it('classifies columns by kind', () => {
+    const grid = getGrid({ showRowNumber: true, rowSelection: true, rowDetail: { content: () => null } });
+    expect(leaf(grid, 'firstName').kind).toBe('data');
+    expect(leaf(grid, ROW_NUMBER_CELL_KEY).kind).toBe('rowNumber');
+    expect(leaf(grid, ROW_SELECTION_CELL_KEY).kind).toBe('rowSelection');
+    expect(leaf(grid, ROW_DETAIL_CELL_KEY).kind).toBe('rowDetail');
+
+    grid.toggleGrouping('firstName');
+    expect(grid.columns.value.leafs.findOrThrow((c) => c.isGrouping).kind).toBe('grouping');
+  });
+
+  it('convenience flags match the kind', () => {
+    const col = leaf(getGrid(), 'firstName');
+    expect(col.isData).toBe(true);
+    expect(col.isRowNumber).toBe(false);
+    expect(col.isRowSelection).toBe(false);
+    expect(col.isRowDetail).toBe(false);
+    expect(col.isGrouping).toBe(false);
+  });
+
+  it('cellVariant / cellStyleVars are stable (memoized) per column instance', () => {
+    const col = leaf(getGrid(), 'firstName');
+    expect(col.cellVariant.value).toBe(col.cellVariant.value);
+    expect(col.cellStyleVars.value).toBe(col.cellStyleVars.value);
+  });
+
+  it('pinFlags reflect pinning', () => {
+    const grid = getGrid({ columns: [{ key: 'firstName', pin: 'LEFT' }, { key: 'age' }] });
+    const flags = leaf(grid, 'firstName').pinFlags.value;
+    expect(flags.isLeftPinned).toBe(true);
+    expect(flags.isFirstLeftPinned).toBe(true);
+  });
+});
+
+describe('ColumnModel filtering helpers', () => {
+  ignoreLogs();
+
+  it('resolves filterConfig (boolean → text, object passthrough)', () => {
+    const grid = getGrid({
+      columns: [{ key: 'firstName', filterable: true }, { key: 'age', filterable: { type: 'number' } }, { key: 'country' }],
+    });
+    expect(leaf(grid, 'firstName').filterConfig).toEqual({ type: 'text' });
+    expect(leaf(grid, 'age').filterConfig).toEqual({ type: 'number' });
+    expect(leaf(grid, 'country').filterConfig).toBeUndefined();
+  });
+
+  it('setTextFilter sets/clears the column filter', () => {
+    const grid = getGrid({ columns: [{ key: 'firstName', filterable: true }] });
+    const col = leaf(grid, 'firstName');
+
+    col.setTextFilter('jo');
+    expect(col.currentFilter).toEqual({ type: 'text', value: 'jo' });
+
+    col.setTextFilter('   ');
+    expect(col.currentFilter).toBeUndefined();
+  });
+
+  it('setNumberFilter validates input and supports between', () => {
+    const grid = getGrid({ columns: [{ key: 'age', filterable: { type: 'number' } }] });
+    const col = leaf(grid, 'age');
+
+    col.setNumberFilter('gte', '21');
+    expect(col.currentFilter).toEqual({ type: 'number', operator: 'gte', value: 21 });
+
+    col.setNumberFilter('between', 20, 30);
+    expect(col.currentFilter).toEqual({ type: 'number', operator: 'between', value: 20, valueTo: 30 });
+
+    col.setNumberFilter('eq', ''); // invalid → clears
+    expect(col.currentFilter).toBeUndefined();
+  });
+
+  it('setMultiselectFilter sets values and clears on empty', () => {
+    const grid = getGrid({ columns: [{ key: 'country', filterable: { type: 'multiselect' } }] });
+    const col = leaf(grid, 'country');
+
+    col.setMultiselectFilter(['USA']);
+    expect(col.currentFilter).toEqual({ type: 'multiselect', values: ['USA'] });
+
+    col.setMultiselectFilter([]);
+    expect(col.currentFilter).toBeUndefined();
+  });
+
+  it('filterOptions computes unique values when no options are configured', () => {
+    const grid = getGrid({ columns: [{ key: 'country', filterable: { type: 'multiselect' } }] });
+    expect(leaf(grid, 'country').filterOptions).toEqual([
+      { label: 'UK', value: 'UK' },
+      { label: 'USA', value: 'USA' },
+    ]);
+  });
+});

--- a/src/components/dataGrid/models/columnModel.resize.test.ts
+++ b/src/components/dataGrid/models/columnModel.resize.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { ignoreLogs } from '../../../../dev/tests';
+import { GridDefinition } from '../contracts/dataGridContract';
+import GridModel from './gridModel';
+
+interface Person {
+  firstName: string;
+  lastName: string;
+}
+
+const data: Person[] = [{ firstName: 'A', lastName: 'X' }];
+
+function getGrid(def: GridDefinition<Person>) {
+  return new GridModel<Person>({ data, def });
+}
+
+describe('ColumnModel resize (headless)', () => {
+  ignoreLogs();
+
+  it('widens a column as the pointer drags right', () => {
+    const grid = getGrid({ columns: [{ key: 'firstName', width: 200 }] });
+    const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+
+    col.beginResize(100);
+    col.resizeTo(160); // +60px
+
+    expect(col.inlineWidth).toBe(260);
+  });
+
+  it('narrows a column as the pointer drags left, clamped to MIN_COLUMN_WIDTH_PX', () => {
+    const grid = getGrid({ columns: [{ key: 'firstName', width: 200 }] });
+    const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+
+    col.beginResize(100);
+    col.resizeTo(-1000); // far past the minimum
+
+    expect(col.inlineWidth).toBe(grid.MIN_COLUMN_WIDTH_PX);
+  });
+
+  it('inverts drag direction for RIGHT-pinned columns', () => {
+    const grid = getGrid({ columns: [{ key: 'firstName', width: 200, pin: 'RIGHT' }] });
+    const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+
+    col.beginResize(100);
+    col.resizeTo(160); // pointer moves right → right-pinned column shrinks
+
+    expect(col.inlineWidth).toBe(140);
+  });
+
+  it('notifies subscribers on each resizeTo and on endResize', () => {
+    const grid = getGrid({ columns: [{ key: 'firstName', width: 200 }] });
+    const col = grid.columns.value.leafs.findOrThrow((c) => c.key === 'firstName');
+
+    const before = grid.getSnapshot();
+    col.beginResize(100);
+    col.resizeTo(120);
+    col.resizeTo(140);
+    col.endResize();
+
+    expect(grid.getSnapshot()).toBe(before + 3);
+  });
+});

--- a/src/components/dataGrid/models/columnModel.ts
+++ b/src/components/dataGrid/models/columnModel.ts
@@ -1,6 +1,18 @@
-import FnUtils from '../../../utils/fn/fnUtils';
-import { ColumnType, ContextMenuConfig, PinPosition } from '../contracts/dataGridContract';
-import GridModel, { EMPTY_CELL_KEY } from './gridModel';
+import memo from '../../../utils/memo';
+import {
+  ColumnFilterConfig,
+  ColumnType,
+  ContextMenuConfig,
+  FilterValue,
+  Key,
+  NumberFilterValue,
+  PinPosition,
+} from '../contracts/dataGridContract';
+import GridModel, { GROUPING_CELL_KEY, ROW_DETAIL_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from './gridModel';
+import HeaderCellModel from './headerCellModel';
+
+/** Discriminates the structural role of a column — replaces scattered `key === *_CELL_KEY` checks. */
+export type ColumnKind = 'data' | 'rowNumber' | 'rowSelection' | 'rowDetail' | 'grouping';
 
 export default class ColumnModel<TRow> {
   constructor(
@@ -13,12 +25,99 @@ export default class ColumnModel<TRow> {
     if (this.isLeaf) {
       // Use stored width if available (survives memo recreation), otherwise use def.width or default
       const storedWidth = this.grid.columnWidths.get(this.key);
-      this._inlineWidth = this.key == EMPTY_CELL_KEY ? undefined : (storedWidth ?? this.def.width ?? this.grid.DEFAULT_COLUMN_WIDTH_PX);
+      this._inlineWidth = storedWidth ?? this.def.width ?? this.grid.DEFAULT_COLUMN_WIDTH_PX;
       this._pin = def.pin;
     }
   }
 
   public columns: ColumnModel<TRow>[] = [];
+
+  // ========== Kind (replaces scattered `key === *_CELL_KEY` checks) ==========
+
+  public get kind(): ColumnKind {
+    switch (this.key) {
+      case ROW_NUMBER_CELL_KEY:
+        return 'rowNumber';
+      case ROW_SELECTION_CELL_KEY:
+        return 'rowSelection';
+      case ROW_DETAIL_CELL_KEY:
+        return 'rowDetail';
+      case GROUPING_CELL_KEY:
+        return 'grouping';
+      default:
+        return 'data';
+    }
+  }
+
+  public get isRowNumber(): boolean {
+    return this.kind === 'rowNumber';
+  }
+  public get isRowSelection(): boolean {
+    return this.kind === 'rowSelection';
+  }
+  public get isRowDetail(): boolean {
+    return this.kind === 'rowDetail';
+  }
+  public get isGrouping(): boolean {
+    return this.kind === 'grouping';
+  }
+  public get isData(): boolean {
+    return this.kind === 'data';
+  }
+
+  // ========== Precomputed cell layout (stable for the column's lifetime) ==========
+  // Pin flags depend only on column order/pinning/visibility — never on width — so they
+  // stay valid until `columns` is rebuilt (which produces fresh column instances). The
+  // memos have no deps: they just cache lazily per instance.
+
+  public readonly pinFlags = memo(() => {
+    const isLeftPinned = this.pin === 'LEFT';
+    const isRightPinned = this.pin === 'RIGHT';
+    return {
+      isLeftPinned,
+      isRightPinned,
+      isPinned: isLeftPinned || isRightPinned,
+      isFirstLeftPinned: isLeftPinned && this.left === 0,
+      isLastLeftPinned: isLeftPinned && this.isEdge,
+      isFirstRightPinned: isRightPinned && this.isEdge,
+      isLastRightPinned: isRightPinned && this.right === 0,
+    };
+  });
+
+  /** Variant flags for the body cell that depend only on the column (not the row). */
+  public readonly cellVariant = memo(() => {
+    const { isPinned, isFirstLeftPinned, isLastLeftPinned, isFirstRightPinned, isLastRightPinned } = this.pinFlags.value;
+    return {
+      isPinned,
+      isFirstLeftPinned,
+      isLastLeftPinned,
+      isFirstRightPinned,
+      isLastRightPinned,
+      isRowSelection: this.isRowSelection,
+      isRowNumber: this.isRowNumber,
+      isFirstLeaf: this.isFirstLeaf,
+      isLastLeaf: this.isLastLeaf,
+      isRowDetail: this.isRowDetail,
+    };
+  });
+
+  /** Static CSS-var references for the body/filter cell (stable string identity). */
+  public readonly cellStyleVars = memo(() => {
+    const { isLeftPinned, isRightPinned } = this.pinFlags.value;
+    return {
+      width: `var(${this.widthVarName})`,
+      height: `var(${this.grid.rowHeightVarName})`,
+      left: isLeftPinned ? `var(${this.leftVarName})` : undefined,
+      right: isRightPinned ? `var(${this.rightVarName})` : undefined,
+    };
+  });
+
+  /** Derived state for this column's header cell + context menu. */
+  private readonly _headerCell = memo(() => new HeaderCellModel(this));
+  public get headerCell(): HeaderCellModel<TRow> {
+    return this._headerCell.value;
+  }
+
   public get visibleColumns() {
     return this.columns.filter((c) => c.isVisible);
   }
@@ -44,6 +143,10 @@ export default class ColumnModel<TRow> {
   public get align() {
     return this.def.align;
   }
+  /** Whether an explicit `align` was provided (mirrors the original `'align' in def` check). */
+  public get hasAlign(): boolean {
+    return 'align' in this.def;
+  }
   public get isLeaf() {
     return this.columns.length === 0;
   }
@@ -52,6 +155,60 @@ export default class ColumnModel<TRow> {
   }
   public get filterable() {
     return this.def.filterable;
+  }
+
+  // ========== Column filtering (resolves config + parses/validates input) ==========
+
+  /** Resolved filter config, or undefined when this column isn't filterable. */
+  public get filterConfig(): ColumnFilterConfig | undefined {
+    const { filterable } = this.def;
+    if (!filterable) return undefined;
+    return typeof filterable === 'object' ? filterable : { type: 'text' };
+  }
+
+  /** The active filter on this column, if any. */
+  public get currentFilter(): FilterValue | undefined {
+    return this.grid.columnFilters[this.key as keyof TRow];
+  }
+
+  /** Options for a multiselect filter (config-provided, else unique values from data). */
+  public get filterOptions(): { label: string; value: string | number | boolean | null }[] {
+    const config = this.filterConfig;
+    if (config?.type === 'multiselect' && config.options) return config.options;
+
+    return this.grid.getColumnUniqueValues(this.key).map((value) => ({
+      label: value === null ? '(empty)' : String(value),
+      value,
+    }));
+  }
+
+  public setTextFilter(value: string): void {
+    this.grid.setColumnFilter(this.key, value.trim() ? { type: 'text', value } : undefined);
+  }
+
+  public setNumberFilter(operator: NumberFilterValue['operator'], value: string | number, valueTo?: string | number): void {
+    const numVal = typeof value === 'number' ? value : parseFloat(value);
+    if (isNaN(numVal) || value === '') {
+      this.grid.setColumnFilter(this.key, undefined);
+      return;
+    }
+
+    const filter: NumberFilterValue = { type: 'number', operator, value: numVal };
+
+    if (operator === 'between' && valueTo !== undefined && valueTo !== '') {
+      const numValTo = typeof valueTo === 'number' ? valueTo : parseFloat(String(valueTo));
+      if (!isNaN(numValTo)) filter.valueTo = numValTo;
+    }
+
+    this.grid.setColumnFilter(this.key, filter);
+  }
+
+  public setMultiselectFilter(values: (string | number | boolean | null)[]): void {
+    this.grid.setColumnFilter(this.key, values.length === 0 ? undefined : { type: 'multiselect', values });
+  }
+
+  public clearFilter(): void {
+    this.grid.setColumnFilter(this.key, undefined);
   }
 
   /** Whether sorting is enabled for this column. Column-level setting takes priority over grid-level. */
@@ -260,40 +417,45 @@ export default class ColumnModel<TRow> {
     return this.isLeaf ? this.grid.columns.value.maxDeath - this.death : 1;
   }
 
-  public resizeColumn = (e: unknown) => {
-    const startPageX = (e as MouseEvent).pageX;
-    const { MIN_COLUMN_WIDTH_PX: MIN_WIDTH_PX, update } = this.grid;
+  // ========== Resize (headless: pure coordinate math, DOM events live in the adapter) ==========
 
-    // Capture current visual widths (includes flex-calculated width) as starting point
-    const sizes = this.leafs.toRecord((leaf) => [leaf.key, leaf.inlineWidth ?? leaf.baseWidth]);
-    const totalWidth = this.leafs.sumBy((c) => sizes[c.key]) - this.leafs.length * MIN_WIDTH_PX;
+  private _resizeStartX = 0;
+  private _resizeSizes: Record<Key, number> = {};
+  private _resizeTotalWidth = 0;
 
-    const resize = FnUtils.throttle((e: MouseEvent) => {
-      const dragDistance = (e.pageX - startPageX) * (this.pin === 'RIGHT' ? -1 : 1);
+  /** Begin a resize drag from a pointer x-coordinate (page space). */
+  public beginResize = (startX: number): void => {
+    const { MIN_COLUMN_WIDTH_PX } = this.grid;
 
-      this.leafs.forEach((leaf) => {
-        const width = sizes[leaf.key];
-        const dragDistanceForCell =
-          totalWidth > 0 ? ((width - MIN_WIDTH_PX) / totalWidth) * dragDistance : dragDistance / this.leafs.length;
-        const newWidth = Math.round(width + dragDistanceForCell);
+    this._resizeStartX = startX;
+    // Capture current visual widths (includes flex-calculated width) as starting point.
+    this._resizeSizes = this.leafs.toRecord((leaf) => [leaf.key, leaf.inlineWidth ?? leaf.baseWidth]);
+    this._resizeTotalWidth = this.leafs.sumBy((c) => this._resizeSizes[c.key]) - this.leafs.length * MIN_COLUMN_WIDTH_PX;
+  };
 
-        leaf.setWidth(newWidth < MIN_WIDTH_PX ? MIN_WIDTH_PX : newWidth);
-      });
+  /** Apply the drag to a new pointer x-coordinate, distributing the delta across leafs. Notifies subscribers. */
+  public resizeTo = (currentX: number): void => {
+    const { MIN_COLUMN_WIDTH_PX } = this.grid;
+    const dragDistance = (currentX - this._resizeStartX) * (this.pin === 'RIGHT' ? -1 : 1);
 
-      this.grid.flexWidths.clear();
-      this.grid.sizes.clear();
-      update();
-    }, 40);
+    this.leafs.forEach((leaf) => {
+      const width = this._resizeSizes[leaf.key];
+      const dragDistanceForCell =
+        this._resizeTotalWidth > 0
+          ? ((width - MIN_COLUMN_WIDTH_PX) / this._resizeTotalWidth) * dragDistance
+          : dragDistance / this.leafs.length;
+      const newWidth = Math.round(width + dragDistanceForCell);
 
-    const controller = new AbortController();
+      leaf.setWidth(newWidth < MIN_COLUMN_WIDTH_PX ? MIN_COLUMN_WIDTH_PX : newWidth);
+    });
 
-    const stopResize = (_e: MouseEvent) => {
-      controller.abort();
-      update();
-    };
+    this.grid.flexWidths.clear(); // cascades to sizes
+    this.grid.notify();
+  };
 
-    window.addEventListener('mousemove', resize, controller);
-    window.addEventListener('mouseup', stopResize, controller);
+  /** End a resize drag. */
+  public endResize = (): void => {
+    this.grid.notify();
   };
 
   public pinColumn = (pin?: PinPosition) => {

--- a/src/components/dataGrid/models/columnVisibilityModel.test.ts
+++ b/src/components/dataGrid/models/columnVisibilityModel.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { ignoreLogs } from '../../../../dev/tests';
+import { GridDefinition } from '../contracts/dataGridContract';
+import GridModel from './gridModel';
+
+interface Person {
+  firstName: string;
+  lastName: string;
+  age: number;
+}
+
+const data: Person[] = [{ firstName: 'John', lastName: 'Doe', age: 20 }];
+
+function getGrid(def?: Partial<GridDefinition<Person>>) {
+  return new GridModel<Person>({
+    data,
+    def: { columns: [{ key: 'firstName', header: 'First' }, { key: 'lastName' }, { key: 'age' }], ...def },
+  });
+}
+
+describe('ColumnVisibilityModel', () => {
+  ignoreLogs();
+
+  it('lists only user data columns, with header-or-key labels', () => {
+    const cv = getGrid({ showRowNumber: true, rowSelection: true }).columnVisibility;
+    expect(cv.entries.map((e) => e.id)).toEqual(['firstName', 'lastName', 'age']);
+    expect(cv.entries.map((e) => e.label)).toEqual(['First', 'lastName', 'age']);
+    expect(cv.total).toBe(3);
+  });
+
+  it('reports all selected with nothing hidden initially', () => {
+    const cv = getGrid().columnVisibility;
+    expect(cv.selectedIds).toEqual(['firstName', 'lastName', 'age']);
+    expect(cv.hiddenCount).toBe(0);
+    expect(cv.hasHidden).toBe(false);
+  });
+
+  it('setVisibility hides the columns not listed (and only toggles what changed)', () => {
+    const grid = getGrid();
+    grid.columnVisibility.setVisibility(['firstName']);
+
+    expect(grid.columnVisibility.selectedIds).toEqual(['firstName']);
+    expect(grid.columnVisibility.hiddenCount).toBe(2);
+    expect(grid.columnVisibility.hasHidden).toBe(true);
+    expect(grid.hiddenColumns.has('lastName')).toBe(true);
+    expect(grid.hiddenColumns.has('age')).toBe(true);
+    expect(grid.hiddenColumns.has('firstName')).toBe(false);
+  });
+
+  it('setVisibility can re-show a hidden column', () => {
+    const grid = getGrid();
+    grid.columnVisibility.setVisibility(['firstName']);
+    grid.columnVisibility.setVisibility(['firstName', 'lastName', 'age']);
+
+    expect(grid.columnVisibility.hiddenCount).toBe(0);
+    expect(grid.hiddenColumns.size).toBe(0);
+  });
+});

--- a/src/components/dataGrid/models/columnVisibilityModel.ts
+++ b/src/components/dataGrid/models/columnVisibilityModel.ts
@@ -1,0 +1,56 @@
+import ColumnModel from './columnModel';
+import GridModel from './gridModel';
+
+export interface ColumnVisibilityEntry<TRow> {
+  id: string;
+  label: string;
+  column: ColumnModel<TRow>;
+  visible: boolean;
+}
+
+/**
+ * Backs the top-bar column-visibility menu: the toggleable (user data) columns, which
+ * are currently shown, and a diff-based bulk setter.
+ */
+export default class ColumnVisibilityModel<TRow> {
+  constructor(public readonly grid: GridModel<TRow>) {}
+
+  /** All user data leafs (visible and hidden) — excludes row-number/selection/detail/grouping. */
+  public get entries(): ColumnVisibilityEntry<TRow>[] {
+    return this.grid.columns.value.leafs
+      .filter((c) => c.isData)
+      .map((column) => ({
+        id: String(column.key),
+        label: String(column.header ?? column.key),
+        column,
+        visible: column.isVisible,
+      }));
+  }
+
+  public get selectedIds(): string[] {
+    return this.entries.filter((e) => e.visible).map((e) => e.id);
+  }
+
+  public get total(): number {
+    return this.entries.length;
+  }
+
+  public get hiddenCount(): number {
+    return this.entries.reduce((n, e) => (e.visible ? n : n + 1), 0);
+  }
+
+  public get hasHidden(): boolean {
+    return this.hiddenCount > 0;
+  }
+
+  /** Make exactly the columns in `ids` visible, toggling only those whose state must change. */
+  public setVisibility = (ids: string[]): void => {
+    const next = new Set(ids);
+    this.entries.forEach((entry) => {
+      const shouldBeVisible = next.has(entry.id);
+      if (entry.visible !== shouldBeVisible) {
+        entry.column.toggleVisibility();
+      }
+    });
+  };
+}

--- a/src/components/dataGrid/models/detailRowModel.ts
+++ b/src/components/dataGrid/models/detailRowModel.ts
@@ -8,8 +8,14 @@ export default class DetailRowModel<TRow> {
     public readonly parentRow: RowModel<TRow>,
   ) {}
 
+  public readonly kind = 'detail' as const;
+
   public get key(): Key {
     return `detail-${this.parentRow.key}`;
+  }
+
+  public get isAutoHeight(): boolean {
+    return this.height === 'auto';
   }
 
   public static readonly AUTO_HEIGHT_ESTIMATE = 200;

--- a/src/components/dataGrid/models/filterModel.ts
+++ b/src/components/dataGrid/models/filterModel.ts
@@ -1,0 +1,35 @@
+import { ColumnFilters } from '../contracts/dataGridContract';
+import GridModel from './gridModel';
+
+/**
+ * Filtering concern: grid-level filter state + the derived flags the UI needs. Per-column
+ * filter config/value/parse helpers live on ColumnModel; the coupled mutations (page-reset,
+ * server-state events, filteredData) live on GridModel.
+ */
+export default class FilterModel<TRow> {
+  constructor(public readonly grid: GridModel<TRow>) {}
+
+  public get globalFilterValue(): string {
+    return this.grid.globalFilterValue;
+  }
+
+  public get columnFilters(): ColumnFilters<TRow> {
+    return this.grid.columnFilters;
+  }
+
+  public get hasActiveFilters(): boolean {
+    return this.grid.hasActiveFilters;
+  }
+
+  public get filterStats(): { filtered: number; total: number } {
+    return this.grid.filterStats;
+  }
+
+  /** Whether any visible column is filterable (controls the filter row's visibility). */
+  public get hasFilterableColumns(): boolean {
+    return this.grid.columns.value.visibleLeafs.some((c) => !!c.filterable);
+  }
+
+  public setGlobalFilter = (value: string): void => this.grid.setGlobalFilter(value);
+  public clearAllFilters = (): void => this.grid.clearAllFilters();
+}

--- a/src/components/dataGrid/models/gridModel.pagination.test.ts
+++ b/src/components/dataGrid/models/gridModel.pagination.test.ts
@@ -226,6 +226,73 @@ describe('GridModel Pagination', () => {
     expect(onPageChange).toHaveBeenCalledWith(1, 10);
   });
 
+  // ========== Page size change ==========
+
+  it('changePageSize updates internal pageSize (uncontrolled)', () => {
+    const grid = createGrid();
+    expect(grid.pageSize).toBe(10);
+
+    grid.changePageSize(25);
+    expect(grid.pageSize).toBe(25);
+  });
+
+  it('changePageSize resets page to 1 (uncontrolled)', () => {
+    const grid = createGrid();
+    grid.changePage(3);
+    expect(grid.page).toBe(3);
+
+    grid.changePageSize(25);
+    expect(grid.page).toBe(1);
+  });
+
+  it('changePageSize calls onPageSizeChange callback (controlled)', () => {
+    const onPageSizeChange = vi.fn();
+    const grid = createGrid({ onPageSizeChange });
+
+    grid.changePageSize(25);
+    expect(onPageSizeChange).toHaveBeenCalledWith(25);
+  });
+
+  it('changePageSize calls onPageChange with page 1 and new size (controlled)', () => {
+    const onPageChange = vi.fn();
+    const grid = createGrid({ page: 2, onPageChange });
+
+    grid.changePageSize(25);
+    expect(onPageChange).toHaveBeenCalledWith(1, 25);
+  });
+
+  it('changePageSize does not fire when size is unchanged', () => {
+    const onPageSizeChange = vi.fn();
+    const grid = createGrid({ onPageSizeChange });
+
+    grid.changePageSize(10); // same as default
+    expect(onPageSizeChange).not.toHaveBeenCalled();
+  });
+
+  it('controlled pageSize prop overrides internal state', () => {
+    const grid = createGrid({ pageSize: 25 });
+    expect(grid.pageSize).toBe(25);
+  });
+
+  it('pageSizeOptions returns options from pagination config', () => {
+    const grid = createGrid({ def: { ...baseDef, pagination: { totalCount: 50, pageSizeOptions: [10, 25, 50] } } });
+    expect(grid.pageSizeOptions).toEqual([10, 25, 50]);
+  });
+
+  it('pageSizeOptions returns undefined when not configured', () => {
+    const grid = createGrid();
+    expect(grid.pageSizeOptions).toBeUndefined();
+  });
+
+  it('changePageSize fires onServerStateChange with new pageSize and page 1', () => {
+    const onServerStateChange = vi.fn();
+    const grid = createGrid({ onServerStateChange });
+    grid.changePage(3);
+
+    grid.changePageSize(25);
+    expect(onServerStateChange).toHaveBeenLastCalledWith(expect.objectContaining({ page: 1, pageSize: 25 }));
+  });
+
   // ========== Column filter resets page ==========
 
   it('column filter change resets page to 1 (uncontrolled)', () => {

--- a/src/components/dataGrid/models/gridModel.store.test.ts
+++ b/src/components/dataGrid/models/gridModel.store.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ignoreLogs } from '../../../../dev/tests';
+import { DataGridProps, GridDefinition } from '../contracts/dataGridContract';
+import GridModel from './gridModel';
+
+interface Person {
+  firstName: string;
+  lastName: string;
+}
+
+const data: Person[] = [
+  { firstName: 'A', lastName: 'X' },
+  { firstName: 'B', lastName: 'Y' },
+];
+
+const def: GridDefinition<Person> = { columns: [{ key: 'firstName' }, { key: 'lastName' }] };
+
+function getGrid(props?: Partial<DataGridProps<Person>>) {
+  return new GridModel<Person>({ data, def, ...props });
+}
+
+describe('GridModel store', () => {
+  ignoreLogs();
+
+  it('notifies subscribers and increments the snapshot on mutation', () => {
+    const grid = getGrid();
+    const listener = vi.fn();
+    grid.subscribe(listener);
+
+    const before = grid.getSnapshot();
+    grid.setSortColumn('firstName');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(grid.getSnapshot()).toBe(before + 1);
+  });
+
+  it('getSnapshot is stable between mutations', () => {
+    const grid = getGrid();
+    const a = grid.getSnapshot();
+    const b = grid.getSnapshot();
+    expect(a).toBe(b);
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    const grid = getGrid();
+    const listener = vi.fn();
+    const unsubscribe = grid.subscribe(listener);
+
+    grid.setSortColumn('firstName');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    grid.setSortColumn('lastName');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports multiple independent subscribers', () => {
+    const grid = getGrid();
+    const a = vi.fn();
+    const b = vi.fn();
+    grid.subscribe(a);
+    grid.subscribe(b);
+
+    grid.notify();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers the optional constructor onChange listener', () => {
+    const onChange = vi.fn();
+    const grid = new GridModel<Person>({ data, def }, onChange);
+
+    grid.notify();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  describe('setProps', () => {
+    it('is a no-op (no memo rebuild) when the same props object is passed', () => {
+      const grid = getGrid();
+      const rows = grid.rows.value; // prime cache
+      grid.setProps(grid.props);
+      expect(grid.rows.value).toBe(rows); // same cached instance, not recomputed
+    });
+
+    it('rebuilds rows when the data prop changes', () => {
+      const grid = getGrid();
+      const rows = grid.rows.value;
+
+      const newData: Person[] = [{ firstName: 'C', lastName: 'Z' }];
+      grid.setProps({ data: newData, def });
+
+      expect(grid.rows.value).not.toBe(rows);
+      expect(grid.rows.value).toHaveLength(1);
+    });
+
+    it('rebuilds columns when the def prop changes', () => {
+      const grid = getGrid();
+      const columns = grid.columns.value;
+
+      grid.setProps({ data, def: { columns: [{ key: 'firstName' }] } });
+
+      expect(grid.columns.value).not.toBe(columns);
+      expect(grid.columns.value.userVisibleLeafs).toHaveLength(1);
+    });
+
+    it('does not notify subscribers (render-time sync)', () => {
+      const grid = getGrid();
+      const listener = vi.fn();
+      grid.subscribe(listener);
+
+      grid.setProps({ data: [{ firstName: 'C', lastName: 'Z' }], def });
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/dataGrid/models/gridModel.ts
+++ b/src/components/dataGrid/models/gridModel.ts
@@ -15,11 +15,14 @@ import {
   ServerState,
 } from '../contracts/dataGridContract';
 import ColumnModel from './columnModel';
+import ColumnVisibilityModel from './columnVisibilityModel';
 import DetailRowModel from './detailRowModel';
+import FilterModel from './filterModel';
 import GroupRowModel from './groupRowModel';
+import PaginationModel from './paginationModel';
 import RowModel from './rowModel';
+import ViewportModel from './viewportModel';
 
-export const EMPTY_CELL_KEY: Key = 'empty-cell';
 export const ROW_NUMBER_CELL_KEY: Key = 'row-number-cell';
 export const DEFAULT_ROW_NUMBER_COLUMN_WIDTH = 70;
 export const ROW_SELECTION_CELL_KEY: Key = 'row-selection-cell';
@@ -29,9 +32,65 @@ export const ROW_DETAIL_CELL_KEY: Key = 'row-detail-cell';
 export default class GridModel<TRow> {
   constructor(
     public props: DataGridProps<TRow>,
-    public readonly update: () => void,
+    onChange?: () => void,
   ) {
+    if (onChange) this.listeners.add(onChange);
     console.debug('\x1b[32m%s\x1b[0m', '[react-box]: DataGrid GridModel ctor');
+  }
+
+  // ========== Observable store (framework-agnostic) ==========
+  // The grid is a headless store: any framework binds by subscribing. React uses
+  // useSyncExternalStore(subscribe, getSnapshot). Mutations call notify() after
+  // updating state + clearing the affected memos.
+
+  private _version = 0;
+  private readonly listeners = new Set<() => void>();
+
+  /** Subscribe to changes; returns an unsubscribe function. */
+  public subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  /** Monotonic snapshot version — stable between changes, increments on notify(). */
+  public getSnapshot = (): number => this._version;
+
+  /** Signal subscribers that state changed and a re-render is needed. */
+  public notify = (): void => {
+    this._version++;
+    this.listeners.forEach((listener) => listener());
+  };
+
+  /**
+   * Sync incoming props. Called during render by the framework adapter — clears
+   * the affected memos but does NOT notify (no extra render cycle; memos recompute
+   * lazily on next access).
+   */
+  public setProps(props: DataGridProps<TRow>): void {
+    const prev = this.props;
+    if (prev === props) return;
+
+    this.props = props;
+
+    // Definition changed → column structure/layout changed; clearing sourceColumns
+    // cascades through columns → headers/layout/rows.
+    if (prev.def !== props.def) {
+      this.sourceColumns.clear();
+    }
+
+    // Any row-affecting prop changed → rebuild rows (cascades to flatRows/rowOffsets).
+    if (
+      prev.data !== props.data ||
+      prev.def !== props.def ||
+      prev.globalFilterValue !== props.globalFilterValue ||
+      prev.columnFilters !== props.columnFilters ||
+      prev.filters !== props.filters ||
+      prev.expandedRowKeys !== props.expandedRowKeys ||
+      prev.page !== props.page ||
+      prev.pageSize !== props.pageSize
+    ) {
+      this.rows.clear();
+    }
   }
 
   public get componentName(): keyof ComponentsAndVariants {
@@ -88,60 +147,68 @@ export default class GridModel<TRow> {
     return sourceColumns;
   });
 
-  public readonly columns = memo(() => {
-    console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid columns memo');
+  public readonly columns = memo(
+    () => {
+      console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid columns memo');
 
-    const left = this.sourceColumns.value.map((c) => c.getPinnedColumn('LEFT')).filter((c) => !!c);
-    const middle = this.sourceColumns.value.map((c) => c.getPinnedColumn()).filter((c) => !!c);
-    const right = this.sourceColumns.value.map((c) => c.getPinnedColumn('RIGHT')).filter((c) => !!c);
-    const flat = [...left, ...middle, ...right].flatMap((c) => c.flatColumns);
-    const leafs = flat.filter((x) => x.isLeaf);
-    const visibleLeafs = flat.filter((x) => x.isLeaf && x.isVisible);
-    const userVisibleLeafs = visibleLeafs.filter(
-      (c) =>
-        !([EMPTY_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY, GROUPING_CELL_KEY, ROW_DETAIL_CELL_KEY] as Key[]).includes(c.key),
-    );
-    const maxDeath = flat.maxBy((x) => x.death) + 1;
+      const left = this.sourceColumns.value.map((c) => c.getPinnedColumn('LEFT')).filter((c) => !!c);
+      const middle = this.sourceColumns.value.map((c) => c.getPinnedColumn()).filter((c) => !!c);
+      const right = this.sourceColumns.value.map((c) => c.getPinnedColumn('RIGHT')).filter((c) => !!c);
+      const flat = [...left, ...middle, ...right].flatMap((c) => c.flatColumns);
+      const leafs = flat.filter((x) => x.isLeaf);
+      const visibleLeafs = flat.filter((x) => x.isLeaf && x.isVisible);
+      const userVisibleLeafs = visibleLeafs.filter(
+        (c) => !([ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY, GROUPING_CELL_KEY, ROW_DETAIL_CELL_KEY] as Key[]).includes(c.key),
+      );
+      const maxDeath = flat.maxBy((x) => x.death) + 1;
 
-    return {
-      left,
-      middle,
-      right,
-      flat,
-      leafs,
-      visibleLeafs,
-      userVisibleLeafs,
-      maxDeath,
-    };
-  });
+      return {
+        left,
+        middle,
+        right,
+        flat,
+        leafs,
+        visibleLeafs,
+        userVisibleLeafs,
+        maxDeath,
+      };
+    },
+    () => [this.sourceColumns],
+  );
 
-  public readonly headerRows = memo(() => {
-    console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid headerRows memo');
-    const groupedByLevel = this.columns.value.flat.groupBy((c) => c.death).sortBy((x) => x.key);
+  public readonly headerRows = memo(
+    () => {
+      console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid headerRows memo');
+      const groupedByLevel = this.columns.value.flat.groupBy((c) => c.death).sortBy((x) => x.key);
 
-    return groupedByLevel.map((x) => {
-      const cols = x.values.groupBy((c) => c.pin ?? NO_PIN).toRecord((c) => [c.key, c.values]);
+      return groupedByLevel.map((x) => {
+        const cols = x.values.groupBy((c) => c.pin ?? NO_PIN).toRecord((c) => [c.key, c.values]);
 
-      return [
-        ...(cols.LEFT?.filter((c) => c.isVisible) ?? []),
-        ...(cols.NO_PIN?.filter((c) => c.isVisible) ?? []),
-        ...(cols.RIGHT?.filter((c) => c.isVisible) ?? []),
-      ];
-    });
-  });
+        return [
+          ...(cols.LEFT?.filter((c) => c.isVisible) ?? []),
+          ...(cols.NO_PIN?.filter((c) => c.isVisible) ?? []),
+          ...(cols.RIGHT?.filter((c) => c.isVisible) ?? []),
+        ];
+      });
+    },
+    () => [this.columns],
+  );
 
-  public readonly gridTemplateColumns = memo(() => {
-    console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid gridTemplateColumns memo');
-    const { visibleLeafs } = this.columns.value;
+  public readonly gridTemplateColumns = memo(
+    () => {
+      console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid gridTemplateColumns memo');
+      const { visibleLeafs } = this.columns.value;
 
-    const rightPinnedColumnsCount = visibleLeafs.sumBy((x) => (x.pin === 'RIGHT' ? 1 : 0));
-    const leftAndMiddleCount = visibleLeafs.length - rightPinnedColumnsCount;
+      const rightPinnedColumnsCount = visibleLeafs.sumBy((x) => (x.pin === 'RIGHT' ? 1 : 0));
+      const leftAndMiddleCount = visibleLeafs.length - rightPinnedColumnsCount;
 
-    const left = leftAndMiddleCount > 0 ? `repeat(${leftAndMiddleCount}, max-content)` : '';
-    const right = rightPinnedColumnsCount > 0 ? `repeat(${rightPinnedColumnsCount}, max-content)` : '';
+      const left = leftAndMiddleCount > 0 ? `repeat(${leftAndMiddleCount}, max-content)` : '';
+      const right = rightPinnedColumnsCount > 0 ? `repeat(${rightPinnedColumnsCount}, max-content)` : '';
 
-    return `${left} ${right}`.trim();
-  });
+      return `${left} ${right}`.trim();
+    },
+    () => [this.columns],
+  );
 
   // ========== Filtering ==========
 
@@ -168,7 +235,6 @@ export default class GridModel<TRow> {
       this.columns.value.leafs
         .filter(
           (c) =>
-            c.key !== EMPTY_CELL_KEY &&
             c.key !== ROW_NUMBER_CELL_KEY &&
             c.key !== ROW_SELECTION_CELL_KEY &&
             c.key !== GROUPING_CELL_KEY &&
@@ -288,7 +354,7 @@ export default class GridModel<TRow> {
   private fireServerStateChange(overrides?: Partial<ServerState<TRow>>): void {
     this.props.onServerStateChange?.({
       page: overrides?.page ?? this.page,
-      pageSize: this.pageSize,
+      pageSize: overrides?.pageSize ?? this.pageSize,
       sortColumn: 'sortColumn' in (overrides ?? {}) ? overrides!.sortColumn : this._sortColumn,
       sortDirection: 'sortDirection' in (overrides ?? {}) ? overrides!.sortDirection : this._sortDirection,
       columnFilters: overrides?.columnFilters ?? this.columnFilters,
@@ -318,10 +384,8 @@ export default class GridModel<TRow> {
 
     this.fireServerStateChange({ globalFilterValue: value, page: nextPage });
 
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.update();
+    this.rows.clear(); // cascades to flatRows/rowOffsets
+    this.notify();
   };
 
   /**
@@ -354,10 +418,8 @@ export default class GridModel<TRow> {
 
     this.fireServerStateChange({ columnFilters: newFilters, page: nextPage });
 
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.update();
+    this.rows.clear(); // cascades to flatRows/rowOffsets
+    this.notify();
   };
 
   /**
@@ -372,10 +434,8 @@ export default class GridModel<TRow> {
 
     this.fireServerStateChange({ columnFilters: {} });
 
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.update();
+    this.rows.clear(); // cascades to flatRows/rowOffsets
+    this.notify();
   };
 
   /**
@@ -429,111 +489,120 @@ export default class GridModel<TRow> {
     };
   }
 
-  public readonly rows = memo(() => {
-    console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid rows memo');
-    let data = this.filteredData;
+  public readonly rows = memo(
+    () => {
+      console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid rows memo');
+      let data = this.filteredData;
 
-    if (this._sortColumn && !this.isPaginated) {
-      data = data.sortBy((x) => x[this._sortColumn as keyof TRow], this._sortDirection);
-    }
+      if (this._sortColumn && !this.isPaginated) {
+        data = data.sortBy((x) => x[this._sortColumn as keyof TRow], this._sortDirection);
+      }
 
-    if (this.groupColumns.size > 0) {
-      const getRowsGroup = (dataToGroup: TRow[], groupColumns: Set<Key>, rowIndex: number): GroupRowModel<TRow>[] => {
-        const groupKey = groupColumns.values().next().value!;
-        groupColumns.delete(groupKey);
-        const column = this.columns.value.leafs.findOrThrow((c) => c.key === groupKey);
+      if (this.groupColumns.size > 0) {
+        const getRowsGroup = (dataToGroup: TRow[], groupColumns: Set<Key>, rowIndex: number): GroupRowModel<TRow>[] => {
+          const groupKey = groupColumns.values().next().value!;
+          groupColumns.delete(groupKey);
+          const column = this.columns.value.leafs.findOrThrow((c) => c.key === groupKey);
 
-        if (this._sortColumn === GROUPING_CELL_KEY) {
-          dataToGroup = dataToGroup.sortBy((x) => x[groupKey as keyof TRow], this._sortDirection);
-        }
+          if (this._sortColumn === GROUPING_CELL_KEY) {
+            dataToGroup = dataToGroup.sortBy((x) => x[groupKey as keyof TRow], this._sortDirection);
+          }
 
-        return dataToGroup
-          .groupBy((item) => item[groupKey as keyof TRow] as Key)
-          .map((group) => {
-            let rows: RowModel<TRow>[] | GroupRowModel<TRow>[];
+          return dataToGroup
+            .groupBy((item) => item[groupKey as keyof TRow] as Key)
+            .map((group) => {
+              let rows: RowModel<TRow>[] | GroupRowModel<TRow>[];
 
-            if (groupColumns.size > 0) {
-              rows = getRowsGroup(group.values, new Set(groupColumns), rowIndex + 1);
-            } else {
-              rows = group.values.map((dataRow, index) => new RowModel(this, dataRow, rowIndex + 1 + index));
-            }
+              if (groupColumns.size > 0) {
+                rows = getRowsGroup(group.values, new Set(groupColumns), rowIndex + 1);
+              } else {
+                rows = group.values.map((dataRow, index) => new RowModel(this, dataRow, rowIndex + 1 + index));
+              }
 
-            const groupRow = new GroupRowModel(this, column, rows, rowIndex, group.key);
-            rowIndex += 1;
+              const groupRow = new GroupRowModel(this, column, rows, rowIndex, group.key);
+              rowIndex += 1;
 
-            if (groupRow.expanded) {
-              rowIndex += rows.length;
-            }
+              if (groupRow.expanded) {
+                rowIndex += rows.length;
+              }
 
-            return groupRow;
-          });
-      };
+              return groupRow;
+            });
+        };
 
-      return getRowsGroup(data, new Set(this.groupColumns), 0);
-    }
+        return getRowsGroup(data, new Set(this.groupColumns), 0);
+      }
 
-    return data.map((dataRow, rowIndex) => new RowModel(this, dataRow, rowIndex));
-  });
+      return data.map((dataRow, rowIndex) => new RowModel(this, dataRow, rowIndex));
+    },
+    () => [this.columns],
+  );
 
-  public readonly flatRows = memo(() => {
-    console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid flatRows memo');
+  public readonly flatRows = memo(
+    () => {
+      console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid flatRows memo');
 
-    return this.rows.value.flatMap((row) => {
-      return row.flatRows as (RowModel<TRow> | GroupRowModel<TRow> | DetailRowModel<TRow>)[];
-    });
-  });
+      return this.rows.value.flatMap((row) => {
+        return row.flatRows as (RowModel<TRow> | GroupRowModel<TRow> | DetailRowModel<TRow>)[];
+      });
+    },
+    () => [this.rows],
+  );
 
   public get rowHeight() {
     return this.props.def.rowHeight ?? this.DEFAULT_ROW_HEIGHT_PX;
   }
 
-  public readonly sizes = memo(() => {
-    console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid sizes memo');
+  public readonly sizes = memo(
+    () => {
+      console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid sizes memo');
 
-    const size = this.columns.value.flat.reduce<Record<string, string>>((acc, c) => {
-      const { inlineWidth } = c;
-      if (typeof inlineWidth === 'number') {
-        acc[c.widthVarName] = `${c.inlineWidth}px`;
+      const size = this.columns.value.flat.reduce<Record<string, string>>((acc, c) => {
+        const { inlineWidth } = c;
+        if (typeof inlineWidth === 'number') {
+          acc[c.widthVarName] = `${c.inlineWidth}px`;
+        }
+
+        if (c.pin === 'LEFT') {
+          acc[c.leftVarName] = `${c.left}px`;
+        }
+
+        if (c.pin === 'RIGHT') {
+          acc[c.rightVarName] = `${c.right}px`;
+        }
+
+        return acc;
+      }, {});
+
+      size[this.rowHeightVarName] = `${this.rowHeight}px`;
+      size[this.leftEdgeVarName] = `${this.leftEdge}px`;
+      if (this._containerWidth > 0) {
+        size[this.viewportWidthVarName] = `${this._containerWidth}px`;
       }
 
-      if (c.pin === 'LEFT') {
-        acc[c.leftVarName] = `${c.left}px`;
+      const { visibleLeafs } = this.columns.value;
+      const groupingColumn = visibleLeafs.find((c) => c.key === GROUPING_CELL_KEY);
+      if (groupingColumn) {
+        const groupingColumnSize = visibleLeafs.sumBy((c) => {
+          return c.pin === groupingColumn.pin &&
+            c.key !== ROW_NUMBER_CELL_KEY &&
+            c.key !== ROW_SELECTION_CELL_KEY &&
+            c.key !== ROW_DETAIL_CELL_KEY
+            ? (c.inlineWidth ?? 0)
+            : 0;
+        });
+        size[groupingColumn.groupColumnWidthVarName] = `${groupingColumnSize}px`;
       }
 
-      if (c.pin === 'RIGHT') {
-        acc[c.rightVarName] = `${c.right}px`;
-      }
-
-      return acc;
-    }, {});
-
-    size[this.rowHeightVarName] = `${this.rowHeight}px`;
-    size[this.leftEdgeVarName] = `${this.leftEdge}px`;
-    if (this._containerWidth > 0) {
-      size[this.viewportWidthVarName] = `${this._containerWidth}px`;
-    }
-
-    const { visibleLeafs } = this.columns.value;
-    const groupingColumn = visibleLeafs.find((c) => c.key === GROUPING_CELL_KEY);
-    if (groupingColumn) {
-      const groupingColumnSize = visibleLeafs.sumBy((c) => {
-        return c.pin === groupingColumn.pin &&
-          c.key !== ROW_NUMBER_CELL_KEY &&
-          c.key !== ROW_SELECTION_CELL_KEY &&
-          c.key !== ROW_DETAIL_CELL_KEY
-          ? (c.inlineWidth ?? 0)
-          : 0;
+      this.groupColumns.forEach((key) => {
+        const col = this.columns.value.leafs.findOrThrow((c) => c.key === key);
+        size[col.groupColumnWidthVarName] = `${visibleLeafs.sumBy((c) => (c.pin === col.pin ? (c.inlineWidth ?? 0) : 0))}px`;
       });
-      size[groupingColumn.groupColumnWidthVarName] = `${groupingColumnSize}px`;
-    }
 
-    this.groupColumns.forEach((key) => {
-      const col = this.columns.value.leafs.findOrThrow((c) => c.key === key);
-      size[col.groupColumnWidthVarName] = `${visibleLeafs.sumBy((c) => (c.pin === col.pin ? (c.inlineWidth ?? 0) : 0))}px`;
-    });
-
-    return size;
-  });
+      return size;
+    },
+    () => [this.columns, this.flexWidths],
+  );
 
   // ========== Flexible Column Sizing ==========
 
@@ -545,56 +614,58 @@ export default class GridModel<TRow> {
   public setContainerWidth = (width: number) => {
     if (this._containerWidth !== width) {
       this._containerWidth = width;
-      this.flexWidths.clear();
-      this.sizes.clear();
-      this.update();
+      this.flexWidths.clear(); // cascades to sizes
+      this.notify();
     }
   };
 
-  public readonly flexWidths = memo(() => {
-    console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid flexWidths memo');
+  public readonly flexWidths = memo(
+    () => {
+      console.debug('\x1b[36m%s\x1b[0m', '[react-box]: DataGrid flexWidths memo');
 
-    const containerWidth = this._containerWidth;
-    if (containerWidth <= 0) return {};
+      const containerWidth = this._containerWidth;
+      if (containerWidth <= 0) return {};
 
-    const visibleLeafs = this.columns.value.visibleLeafs.filter((c) => c.key !== EMPTY_CELL_KEY);
+      const visibleLeafs = this.columns.value.visibleLeafs;
 
-    // A column is "fixed" if: flexible: false OR it has been manually resized (in columnWidths)
-    const isColumnFixed = (c: ColumnModel<TRow>) => !c.isFlexible || this.columnWidths.has(c.key);
+      // A column is "fixed" if: flexible: false OR it has been manually resized (in columnWidths)
+      const isColumnFixed = (c: ColumnModel<TRow>) => !c.isFlexible || this.columnWidths.has(c.key);
 
-    // Sum of fixed column widths
-    const fixedWidth = visibleLeafs.filter(isColumnFixed).sumBy((c) => c.baseWidth);
+      // Sum of fixed column widths
+      const fixedWidth = visibleLeafs.filter(isColumnFixed).sumBy((c) => c.baseWidth);
 
-    // Flexible columns (not fixed and not manually resized)
-    const flexCols = visibleLeafs.filter((c) => !isColumnFixed(c));
-    const totalFlexBase = flexCols.sumBy((c) => c.baseWidth);
+      // Flexible columns (not fixed and not manually resized)
+      const flexCols = visibleLeafs.filter((c) => !isColumnFixed(c));
+      const totalFlexBase = flexCols.sumBy((c) => c.baseWidth);
 
-    // Available space for flex columns
-    const availableSpace = containerWidth - fixedWidth;
+      // Available space for flex columns
+      const availableSpace = containerWidth - fixedWidth;
 
-    // Distribute proportionally (never shrink below base width)
-    if (availableSpace <= totalFlexBase) {
-      // Not enough space - use base widths
-      return flexCols.toRecord((c) => [c.key, c.baseWidth]);
-    }
-
-    // Proportional distribution using floor to avoid exceeding available space
-    const result: Record<Key, number> = {};
-    let distributed = 0;
-
-    flexCols.forEach((c, index) => {
-      if (index === flexCols.length - 1) {
-        // Last column gets the remainder to avoid rounding issues
-        result[c.key] = availableSpace - distributed;
-      } else {
-        const width = Math.floor((c.baseWidth / totalFlexBase) * availableSpace);
-        result[c.key] = width;
-        distributed += width;
+      // Distribute proportionally (never shrink below base width)
+      if (availableSpace <= totalFlexBase) {
+        // Not enough space - use base widths
+        return flexCols.toRecord((c) => [c.key, c.baseWidth]);
       }
-    });
 
-    return result;
-  });
+      // Proportional distribution using floor to avoid exceeding available space
+      const result: Record<Key, number> = {};
+      let distributed = 0;
+
+      flexCols.forEach((c, index) => {
+        if (index === flexCols.length - 1) {
+          // Last column gets the remainder to avoid rounding issues
+          result[c.key] = availableSpace - distributed;
+        } else {
+          const width = Math.floor((c.baseWidth / totalFlexBase) * availableSpace);
+          result[c.key] = width;
+          distributed += width;
+        }
+      });
+
+      return result;
+    },
+    () => [this.columns],
+  );
 
   public getFlexWidth(key: Key): number | undefined {
     return this.flexWidths.value[key];
@@ -632,26 +703,31 @@ export default class GridModel<TRow> {
       this._expandedDetailRows = expandedKeys;
     }
 
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.update();
+    this.rows.clear(); // cascades to flatRows/rowOffsets
+    this.notify();
   };
 
   // ========== Pagination ==========
 
   private _page = 1;
+  private _pageSize?: number;
 
   public get page(): number {
     return this.props.page ?? this._page;
   }
 
   public get pageSize(): number {
+    if (this.props.pageSize !== undefined) return this.props.pageSize;
+    if (this._pageSize !== undefined) return this._pageSize;
     const pagination = this.props.def.pagination;
     if (pagination?.pageSize) return pagination.pageSize;
     const vrc = this.props.def.visibleRowsCount;
     if (typeof vrc === 'number') return vrc;
     return 10;
+  }
+
+  public get pageSizeOptions(): number[] | undefined {
+    return this.props.def.pagination?.pageSizeOptions;
   }
 
   public get isPaginated(): boolean {
@@ -685,25 +761,81 @@ export default class GridModel<TRow> {
 
     this.fireServerStateChange({ page: clamped });
 
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.update();
+    this.rows.clear(); // cascades to flatRows/rowOffsets
+    this.notify();
+  };
+
+  public changePageSize = (size: number): void => {
+    if (size === this.pageSize) return;
+
+    if (this.props.onPageSizeChange) {
+      this.props.onPageSizeChange(size);
+    } else {
+      this._pageSize = size;
+    }
+
+    if (this.props.onPageChange) {
+      this.props.onPageChange(1, size);
+    } else {
+      this._page = 1;
+    }
+
+    this.fireServerStateChange({ page: 1, pageSize: size });
+
+    this.rows.clear(); // cascades to flatRows/rowOffsets
+    this.notify();
   };
 
   // ========== Row Offsets (for variable-height virtualization) ==========
 
-  public readonly rowOffsets = memo(() => {
-    const offsets: number[] = [];
-    let cumulative = 0;
+  public readonly rowOffsets = memo(
+    () => {
+      const offsets: number[] = [];
+      let cumulative = 0;
 
-    for (const row of this.flatRows.value) {
-      offsets.push(cumulative);
-      cumulative += row instanceof DetailRowModel ? row.heightForOffset : this.rowHeight;
-    }
+      for (const row of this.flatRows.value) {
+        offsets.push(cumulative);
+        cumulative += row instanceof DetailRowModel ? row.heightForOffset : this.rowHeight;
+      }
 
-    return { offsets, totalHeight: cumulative };
-  });
+      return { offsets, totalHeight: cumulative };
+    },
+    () => [this.flatRows],
+  );
+
+  /** Headless virtualization (windowing math; scrollTop is owned by the adapter). */
+  public readonly viewport = new ViewportModel(this);
+
+  /** Backs the top-bar column-visibility menu. */
+  public readonly columnVisibility = new ColumnVisibilityModel(this);
+
+  /** Filtering concern (grid-level state + derived flags). */
+  public readonly filter = new FilterModel(this);
+
+  /** Pagination concern (navigation + row-range derivations). */
+  public readonly pagination = new PaginationModel(this);
+
+  /** Whether any user-facing column is currently visible (else the empty-columns state shows). */
+  public get hasVisibleColumns(): boolean {
+    return this.columns.value.userVisibleLeafs.length > 0;
+  }
+
+  public get isEmpty(): boolean {
+    return this.props.data.length === 0;
+  }
+
+  /** Header select-all checkbox state. */
+  public get allRowsSelected(): boolean {
+    return this.selectedRows.size === this.props.data.length;
+  }
+  public get someRowsSelected(): boolean {
+    return this.selectedRows.size > 0;
+  }
+
+  /** The columns currently grouped, resolved from groupColumns keys (backs the top-bar group chips). */
+  public get groupedColumns(): ColumnModel<TRow>[] {
+    return Array.from(this.groupColumns, (key) => this.columns.value.leafs.findOrThrow((c) => c.key === key));
+  }
 
   public selectedRows: Set<Key> = new Set();
   public get leftEdge() {
@@ -717,6 +849,13 @@ export default class GridModel<TRow> {
   public readonly viewportWidthVarName = '--viewport-width';
 
   private readonly _idMap = new WeakMap<WeakKey, Key>();
+  private _autoId = 0;
+  // No hard DOM/platform dependency: prefer crypto.randomUUID when available, else a counter.
+  private readonly _idFactory: () => Key =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? () => crypto.randomUUID()
+      : () => `auto-row-${this._autoId++}`;
+
   public getRowKey(row: TRow): Key {
     const { rowKey } = this.props.def;
 
@@ -725,7 +864,7 @@ export default class GridModel<TRow> {
     }
 
     if (!this._idMap.has(row as WeakKey)) {
-      this._idMap.set(row as WeakKey, crypto.randomUUID());
+      this._idMap.set(row as WeakKey, this._idFactory());
     }
 
     return this._idMap.get(row as WeakKey)!;
@@ -760,11 +899,8 @@ export default class GridModel<TRow> {
 
     this.fireServerStateChange({ sortColumn: this._sortColumn, sortDirection: this._sortDirection, page: nextPage });
 
-    this.headerRows.clear();
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.update();
+    this.rows.clear(); // cascades to flatRows/rowOffsets (sort doesn't change column structure)
+    this.notify();
   };
 
   public pinColumn = (uniqueKey: string, pin?: PinPosition) => {
@@ -773,16 +909,9 @@ export default class GridModel<TRow> {
       column.pinColumn(pin);
     }
 
-    this.columns.clear();
-    this.headerRows.clear();
-    this.gridTemplateColumns.clear();
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.flexWidths.clear();
-    this.sizes.clear();
+    this.columns.clear(); // cascades to headerRows/gridTemplateColumns/flexWidths/sizes/rows/flatRows/rowOffsets
 
-    this.update();
+    this.notify();
   };
 
   public toggleGrouping = (columnKey: Key) => {
@@ -797,17 +926,9 @@ export default class GridModel<TRow> {
       this.hiddenColumns.add(columnKey);
     }
 
-    this.sourceColumns.clear();
-    this.columns.clear();
-    this.headerRows.clear();
-    this.gridTemplateColumns.clear();
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.flexWidths.clear();
-    this.sizes.clear();
+    this.sourceColumns.clear(); // cascades to columns → headerRows/gridTemplateColumns/flexWidths/sizes/rows/flatRows/rowOffsets
 
-    this.update();
+    this.notify();
   };
 
   public unGroupAll = () => {
@@ -816,16 +937,8 @@ export default class GridModel<TRow> {
     // Ensure previously grouped columns are made visible again
     this.hiddenColumns = new Set(Array.from(this.hiddenColumns).filter((key) => !prevGroupColumns.has(key)));
 
-    this.sourceColumns.clear();
-    this.columns.clear();
-    this.headerRows.clear();
-    this.gridTemplateColumns.clear();
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.flexWidths.clear();
-    this.sizes.clear();
-    this.update();
+    this.sourceColumns.clear(); // cascades to columns → headerRows/gridTemplateColumns/flexWidths/sizes/rows/flatRows/rowOffsets
+    this.notify();
   };
 
   public toggleGroupRow = (groupRowKey: Key) => {
@@ -837,10 +950,8 @@ export default class GridModel<TRow> {
       this.expandedGroupRow.add(groupRowKey);
     }
 
-    this.rows.clear(); // this one is required in order to update rowIndex
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.update();
+    this.rows.clear(); // required to update rowIndex; cascades to flatRows/rowOffsets
+    this.notify();
   };
 
   public toggleRowSelection = (rowKey: Key) => {
@@ -858,9 +969,8 @@ export default class GridModel<TRow> {
       rowKeys.forEach((rowKey) => this.selectedRows.add(rowKey));
     }
 
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.update();
+    this.flatRows.clear(); // cascades to rowOffsets
+    this.notify();
 
     this.props.onSelectionChange?.({
       action: hasAllSelected ? 'deselect' : 'select',
@@ -883,16 +993,9 @@ export default class GridModel<TRow> {
       this.hiddenColumns.add(columnKey);
     }
 
-    this.columns.clear();
-    this.headerRows.clear();
-    this.gridTemplateColumns.clear();
-    this.rows.clear();
-    this.flatRows.clear();
-    this.rowOffsets.clear();
-    this.flexWidths.clear();
-    this.sizes.clear();
+    this.columns.clear(); // cascades to headerRows/gridTemplateColumns/flexWidths/sizes/rows/flatRows/rowOffsets
 
-    this.update();
+    this.notify();
   };
 
   public setWidth = (columnKey: Key, width: number) => {

--- a/src/components/dataGrid/models/gridModel.visibleColumns.test.ts
+++ b/src/components/dataGrid/models/gridModel.visibleColumns.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { ignoreLogs } from '../../../../dev/tests';
 import { GridDefinition } from '../contracts/dataGridContract';
-import GridModel, { EMPTY_CELL_KEY, GROUPING_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from './gridModel';
+import GridModel, { GROUPING_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from './gridModel';
+
+// Legacy key for the removed empty-spacer column; kept as a literal to assert it never appears.
+const EMPTY_CELL_KEY = 'empty-cell';
 
 interface Person {
   firstName: string;

--- a/src/components/dataGrid/models/groupRowCellModel.ts
+++ b/src/components/dataGrid/models/groupRowCellModel.ts
@@ -1,6 +1,15 @@
 import ColumnModel from './columnModel';
-import GridModel, { GROUPING_CELL_KEY, ROW_NUMBER_CELL_KEY } from './gridModel';
+import GridModel from './gridModel';
 import GroupRowModel from './groupRowModel';
+
+/**
+ * How a cell participates in a group row's layout:
+ * - `grouping`  — the expand/label cell (spans the grouped data columns)
+ * - `selection` — the select-all checkbox cell
+ * - `spacer`    — a leading/other-pinned cell rendered with its own value (row number, detail, opposite pin)
+ * - `hidden`    — a data column on the grouping side, absorbed into the grouping cell's column span
+ */
+export type GroupRowCellKind = 'grouping' | 'selection' | 'spacer' | 'hidden';
 
 export default class GroupRowCellModel<TRow> {
   constructor(
@@ -9,10 +18,45 @@ export default class GroupRowCellModel<TRow> {
     public readonly column: ColumnModel<TRow>,
   ) {}
 
-  public get value(): React.ReactNode {
-    if (this.column.key === ROW_NUMBER_CELL_KEY) return this.row.rowIndex + 1;
-    if (this.column.key === GROUPING_CELL_KEY) return `${this.row.groupValue} (${this.row.count})`;
+  public get value(): string | number | null {
+    if (this.column.isRowNumber) return this.row.rowIndex + 1;
+    if (this.column.isGrouping) return `${this.row.groupValue} (${this.row.count})`;
 
     return null;
+  }
+
+  public get cellKind(): GroupRowCellKind {
+    if (this.column.isGrouping) return 'grouping';
+    if (this.column.isRowSelection) return 'selection';
+
+    const { groupingColumn } = this.row;
+    if (this.column.pin !== groupingColumn.pin || this.column.isRowNumber || this.column.isRowDetail) {
+      return 'spacer';
+    }
+
+    return 'hidden';
+  }
+
+  // ========== Grouping-cell layout ==========
+
+  public get depthPadding(): number {
+    return 4 * this.row.depth;
+  }
+
+  public get gridColumnSpan(): number {
+    return this.row.groupingColumnGridColumn;
+  }
+
+  public get widthVar(): string {
+    return `var(${this.column.groupColumnWidthVarName})`;
+  }
+
+  public get isRightPinned(): boolean {
+    return this.column.pin === 'RIGHT';
+  }
+
+  /** Grouping cell shows a right border only when the grouping column is left-pinned. */
+  public get hasGroupingBorder(): boolean {
+    return this.row.groupingColumn.pin === 'LEFT';
   }
 }

--- a/src/components/dataGrid/models/groupRowModel.ts
+++ b/src/components/dataGrid/models/groupRowModel.ts
@@ -1,13 +1,8 @@
+import memo from '../../../utils/memo';
 import { Key } from '../contracts/dataGridContract';
 import ColumnModel from './columnModel';
 import DetailRowModel from './detailRowModel';
-import GridModel, {
-  EMPTY_CELL_KEY,
-  GROUPING_CELL_KEY,
-  ROW_DETAIL_CELL_KEY,
-  ROW_NUMBER_CELL_KEY,
-  ROW_SELECTION_CELL_KEY,
-} from './gridModel';
+import GridModel, { GROUPING_CELL_KEY, ROW_DETAIL_CELL_KEY, ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from './gridModel';
 import GroupRowCellModel from './groupRowCellModel';
 import RowModel from './rowModel';
 
@@ -27,8 +22,9 @@ export default class GroupRowModel<TRow> {
   }
   public parentRow?: GroupRowModel<TRow>;
 
+  private readonly _cells = memo(() => this.grid.columns.value.visibleLeafs.map((c) => new GroupRowCellModel<TRow>(this.grid, this, c)));
   public get cells(): GroupRowCellModel<TRow>[] {
-    return this.grid.columns.value.visibleLeafs.map((c) => new GroupRowCellModel<TRow>(this.grid, this, c));
+    return this._cells.value;
   }
 
   public get selected() {
@@ -72,11 +68,7 @@ export default class GroupRowModel<TRow> {
     const { groupingColumn } = this;
 
     const gridColumn = visibleLeafs.sumBy((c) =>
-      c.pin === groupingColumn.pin &&
-      c.key !== EMPTY_CELL_KEY &&
-      c.key !== ROW_SELECTION_CELL_KEY &&
-      c.key !== ROW_NUMBER_CELL_KEY &&
-      c.key !== ROW_DETAIL_CELL_KEY
+      c.pin === groupingColumn.pin && c.key !== ROW_SELECTION_CELL_KEY && c.key !== ROW_NUMBER_CELL_KEY && c.key !== ROW_DETAIL_CELL_KEY
         ? 1
         : 0,
     );
@@ -84,7 +76,14 @@ export default class GroupRowModel<TRow> {
     return gridColumn;
   }
 
+  public readonly kind = 'group' as const;
+
   public toggleRow() {
     this.grid.toggleGroupRow(this.key);
   }
+
+  /** Select/deselect every leaf row under this group. */
+  public toggleSelectAll = (): void => {
+    this.grid.toggleRowsSelection(this.allRows.map((r) => r.key));
+  };
 }

--- a/src/components/dataGrid/models/headerCellModel.test.ts
+++ b/src/components/dataGrid/models/headerCellModel.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { ignoreLogs } from '../../../../dev/tests';
+import { GridDefinition } from '../contracts/dataGridContract';
+import GridModel, { ROW_NUMBER_CELL_KEY, ROW_SELECTION_CELL_KEY } from './gridModel';
+
+interface Person {
+  firstName: string;
+  lastName: string;
+  age: number;
+}
+
+const data: Person[] = [
+  { firstName: 'John', lastName: 'Doe', age: 20 },
+  { firstName: 'Jane', lastName: 'Smith', age: 22 },
+];
+
+function getGrid(def?: Partial<GridDefinition<Person>>) {
+  return new GridModel<Person>({
+    data,
+    def: { columns: [{ key: 'firstName', header: 'First' }, { key: 'age' }], ...def },
+  });
+}
+
+const leaf = (grid: GridModel<Person>, key: string | number) => grid.columns.value.leafs.findOrThrow((c) => c.key === key);
+
+describe('HeaderCellModel', () => {
+  ignoreLogs();
+
+  describe('label', () => {
+    it('uses header when provided, else the key', () => {
+      const grid = getGrid();
+      expect(leaf(grid, 'firstName').headerCell.label).toBe('First');
+      expect(leaf(grid, 'age').headerCell.label).toBe('age');
+    });
+
+    it('is null for row-number and selection columns', () => {
+      const grid = getGrid({ showRowNumber: true, rowSelection: true });
+      expect(leaf(grid, ROW_NUMBER_CELL_KEY).headerCell.label).toBeNull();
+      expect(leaf(grid, ROW_SELECTION_CELL_KEY).headerCell.label).toBeNull();
+    });
+
+    it('resolves the grouped column header when exactly one group is active', () => {
+      const grid = getGrid();
+      grid.toggleGrouping('firstName');
+      const grouping = grid.columns.value.leafs.findOrThrow((c) => c.isGrouping);
+      expect(grouping.headerCell.label).toBe('First');
+    });
+
+    it('is "Group" when more than one column is grouped', () => {
+      const grid = getGrid();
+      grid.toggleGrouping('firstName');
+      grid.toggleGrouping('age');
+      const grouping = grid.columns.value.leafs.findOrThrow((c) => c.isGrouping);
+      expect(grouping.headerCell.label).toBe('Group');
+    });
+  });
+
+  describe('flags', () => {
+    it('data columns are sortable / resizable / show the context menu by default', () => {
+      const hc = leaf(getGrid(), 'firstName').headerCell;
+      expect(hc.isSortable).toBe(true);
+      expect(hc.showResizer).toBe(true);
+      expect(hc.showContextMenu).toBe(true);
+    });
+
+    it('row-number column is not sortable and shows no resizer/menu', () => {
+      const hc = leaf(getGrid({ showRowNumber: true }), ROW_NUMBER_CELL_KEY).headerCell;
+      expect(hc.isSortable).toBe(false);
+      expect(hc.showResizer).toBe(false);
+      expect(hc.showContextMenu).toBe(false);
+    });
+
+    it('respects column-level sortable: false', () => {
+      const grid = getGrid({ columns: [{ key: 'firstName', sortable: false }] });
+      expect(leaf(grid, 'firstName').headerCell.isSortable).toBe(false);
+    });
+  });
+
+  describe('sort context-menu availability', () => {
+    it('offers asc + desc and no clear when unsorted', () => {
+      const hc = leaf(getGrid(), 'firstName').headerCell;
+      expect(hc.canSortAsc).toBe(true);
+      expect(hc.canSortDesc).toBe(true);
+      expect(hc.canClearSort).toBe(false);
+    });
+
+    it('after ASC: hides asc, offers desc + clear; reflects in isSorted/sortDirection', () => {
+      const grid = getGrid();
+      grid.setSortColumn('firstName', 'ASC');
+      const hc = leaf(grid, 'firstName').headerCell;
+      expect(hc.isSorted).toBe(true);
+      expect(hc.sortDirection).toBe('ASC');
+      expect(hc.canSortAsc).toBe(false);
+      expect(hc.canSortDesc).toBe(true);
+      expect(hc.canClearSort).toBe(true);
+    });
+  });
+
+  describe('pin context-menu availability', () => {
+    it('unpinned column can pin left/right but not unpin', () => {
+      const hc = leaf(getGrid(), 'firstName').headerCell;
+      expect(hc.canPinLeft).toBe(true);
+      expect(hc.canPinRight).toBe(true);
+      expect(hc.canUnpin).toBe(false);
+    });
+
+    it('left-pinned column cannot pin left and can unpin', () => {
+      const grid = getGrid({ columns: [{ key: 'firstName', pin: 'LEFT' }, { key: 'age' }] });
+      const hc = leaf(grid, 'firstName').headerCell;
+      expect(hc.canPinLeft).toBe(false);
+      expect(hc.canUnpin).toBe(true);
+    });
+  });
+
+  describe('group context-menu availability', () => {
+    it('data leaf can group by, grouping column can ungroup all', () => {
+      const grid = getGrid();
+      expect(leaf(grid, 'firstName').headerCell.canGroupBy).toBe(true);
+      grid.toggleGrouping('firstName');
+      const grouping = grid.columns.value.leafs.findOrThrow((c) => c.isGrouping);
+      expect(grouping.headerCell.canGroupBy).toBe(false);
+      expect(grouping.headerCell.canUnGroupAll).toBe(true);
+    });
+  });
+});

--- a/src/components/dataGrid/models/headerCellModel.ts
+++ b/src/components/dataGrid/models/headerCellModel.ts
@@ -1,0 +1,160 @@
+import type ColumnModel from './columnModel';
+import type GridModel from './gridModel';
+
+/** All derived state for rendering a column's header cell and its context menu. */
+export default class HeaderCellModel<TRow> {
+  constructor(public readonly column: ColumnModel<TRow>) {}
+
+  private get grid(): GridModel<TRow> {
+    return this.column.grid;
+  }
+
+  // ========== Header cell ==========
+
+  /** Header label. `null` for the row-number and selection cells (rendered specially). */
+  public get label(): string | number | null {
+    const c = this.column;
+    if (c.isRowNumber || c.isRowSelection) return null;
+
+    if (c.isGrouping) {
+      if (this.grid.groupColumns.size === 1) {
+        const groupedKey = this.grid.groupColumns.values().next().value!;
+        const col = this.grid.columns.value.leafs.findOrThrow((l) => l.key === groupedKey);
+        return col.header ?? col.key;
+      }
+      return 'Group';
+    }
+
+    return c.header ?? c.key;
+  }
+
+  public get isSortable(): boolean {
+    const c = this.column;
+    return c.isLeaf && !c.isRowNumber && !c.isRowSelection && !c.isRowDetail && c.sortable;
+  }
+
+  public get isSorted(): boolean {
+    return this.column.key === this.grid.sortColumn;
+  }
+
+  public get sortDirection(): SortDirection | undefined {
+    return this.grid.sortDirection;
+  }
+
+  public get showResizer(): boolean {
+    const c = this.column;
+    return !c.isRowNumber && !c.isRowSelection && !c.isRowDetail && c.resizable;
+  }
+
+  public get showContextMenu(): boolean {
+    const c = this.column;
+    return !c.isRowNumber && !c.isRowSelection && !c.isRowDetail && c.showContextMenu;
+  }
+
+  /** Grid column span: a leaf occupies one column, a group header spans its leaf count. */
+  public get gridColumn(): number {
+    return this.column.isLeaf ? 1 : this.column.leafs.length;
+  }
+
+  public get paddingLeft(): number | undefined {
+    if (this.column.isRowSelection) return undefined;
+    return this.column.align === 'right' ? 10 : 3;
+  }
+
+  public get paddingRight(): number | undefined {
+    if (this.column.isRowSelection) return undefined;
+    return this.column.align === 'center' ? 3 : undefined;
+  }
+
+  /** Variant flags for the header cell. */
+  public get variant() {
+    const { isPinned, isFirstLeftPinned, isLastLeftPinned, isFirstRightPinned, isLastRightPinned } = this.column.pinFlags.value;
+    return {
+      isPinned,
+      isFirstLeftPinned,
+      isLastLeftPinned,
+      isFirstRightPinned,
+      isLastRightPinned,
+      isSortable: this.isSortable,
+      isRowNumber: this.column.isRowNumber,
+      isFirstLeaf: this.column.isFirstLeaf,
+      isLastLeaf: this.column.isLastLeaf,
+    };
+  }
+
+  /** Variant flags for the context-menu trigger button. */
+  public get contextMenuButtonVariant() {
+    const { isPinned, isFirstLeftPinned, isLastLeftPinned, isFirstRightPinned, isLastRightPinned } = this.column.pinFlags.value;
+    return {
+      isPinned,
+      isFirstLeftPinned,
+      isLastLeftPinned,
+      isFirstRightPinned,
+      isLastRightPinned,
+      isSortable: this.isSortable,
+      isRowNumber: this.column.isRowNumber,
+    };
+  }
+
+  // ========== Context menu availability ==========
+
+  private get sections() {
+    return this.column.contextMenuSections; // { sort, pin, group }
+  }
+
+  public get canSortAsc(): boolean {
+    const { key } = this.column;
+    return (
+      this.sections.sort &&
+      this.column.isLeaf &&
+      this.column.sortable &&
+      (this.grid.sortColumn !== key || this.grid.sortDirection === 'DESC')
+    );
+  }
+
+  public get canSortDesc(): boolean {
+    const { key } = this.column;
+    return (
+      this.sections.sort &&
+      this.column.isLeaf &&
+      this.column.sortable &&
+      (this.grid.sortColumn !== key || this.grid.sortDirection === 'ASC')
+    );
+  }
+
+  public get canClearSort(): boolean {
+    return this.sections.sort && this.column.isLeaf && this.column.sortable && this.grid.sortColumn === this.column.key;
+  }
+
+  public get canPinLeft(): boolean {
+    return this.sections.pin && this.column.pin !== 'LEFT';
+  }
+
+  public get canPinRight(): boolean {
+    return this.sections.pin && this.column.pin !== 'RIGHT';
+  }
+
+  public get canUnpin(): boolean {
+    return this.sections.pin && !!this.column.pin;
+  }
+
+  public get canGroupBy(): boolean {
+    return this.sections.group && this.column.isLeaf && !this.column.isGrouping;
+  }
+
+  public get canUnGroupAll(): boolean {
+    return this.sections.group && this.column.isLeaf && this.column.isGrouping;
+  }
+
+  public get hasSortSection(): boolean {
+    return this.canSortAsc || this.canSortDesc || this.canClearSort;
+  }
+
+  public get hasPinSection(): boolean {
+    return this.canPinLeft || this.canPinRight || this.canUnpin;
+  }
+
+  public get hasGroupSection(): boolean {
+    return this.canGroupBy || this.canUnGroupAll;
+  }
+}

--- a/src/components/dataGrid/models/paginationModel.test.ts
+++ b/src/components/dataGrid/models/paginationModel.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ignoreLogs } from '../../../../dev/tests';
+import { DataGridProps, GridDefinition } from '../contracts/dataGridContract';
+import GridModel from './gridModel';
+
+interface Order {
+  id: number;
+  total: number;
+}
+
+const data: Order[] = Array.from({ length: 10 }, (_, i) => ({ id: i + 1, total: (i + 1) * 10 }));
+
+const def: GridDefinition<Order> = {
+  rowKey: 'id',
+  columns: [{ key: 'total' }],
+  pagination: { totalCount: 50 },
+  visibleRowsCount: 10,
+};
+
+function getGrid(overrides?: Partial<DataGridProps<Order>>) {
+  return new GridModel<Order>({ data, def, ...overrides });
+}
+
+describe('PaginationModel', () => {
+  ignoreLogs();
+
+  it('exposes derived navigation state', () => {
+    const { pagination } = getGrid();
+    expect(pagination.isPaginated).toBe(true);
+    expect(pagination.page).toBe(1);
+    expect(pagination.totalPages).toBe(5);
+    expect(pagination.totalItems).toBe(50);
+    expect(pagination.canGoPrev).toBe(false);
+    expect(pagination.canGoNext).toBe(true);
+  });
+
+  describe('navigation', () => {
+    it('nextPage / prevPage / firstPage / lastPage move within bounds', () => {
+      const { pagination } = getGrid();
+
+      pagination.nextPage();
+      expect(pagination.page).toBe(2);
+
+      pagination.prevPage();
+      expect(pagination.page).toBe(1);
+
+      pagination.prevPage(); // already first → no-op
+      expect(pagination.page).toBe(1);
+
+      pagination.lastPage();
+      expect(pagination.page).toBe(5);
+
+      pagination.nextPage(); // already last → no-op
+      expect(pagination.page).toBe(5);
+
+      pagination.firstPage();
+      expect(pagination.page).toBe(1);
+    });
+
+    it('canGoPrev/canGoNext flip at the boundaries', () => {
+      const { pagination } = getGrid();
+      pagination.lastPage();
+      expect(pagination.canGoPrev).toBe(true);
+      expect(pagination.canGoNext).toBe(false);
+    });
+  });
+
+  describe('jumpToPage', () => {
+    it('navigates to a valid page', () => {
+      const { pagination } = getGrid();
+      pagination.jumpToPage('3');
+      expect(pagination.page).toBe(3);
+    });
+
+    it('clamps out-of-range input', () => {
+      const { pagination } = getGrid();
+      pagination.jumpToPage('999');
+      expect(pagination.page).toBe(5);
+    });
+
+    it('ignores non-numeric input', () => {
+      const { pagination } = getGrid();
+      pagination.jumpToPage('abc');
+      expect(pagination.page).toBe(1);
+    });
+  });
+
+  describe('row range', () => {
+    it('computes startItem / endItem for the current page', () => {
+      const { pagination } = getGrid();
+      expect(pagination.startItem).toBe(1);
+      expect(pagination.endItem).toBe(10);
+
+      pagination.changePage(3);
+      expect(pagination.startItem).toBe(21);
+      expect(pagination.endItem).toBe(30);
+    });
+
+    it('clamps endItem on the last partial page', () => {
+      const grid = getGrid({ def: { ...def, pagination: { totalCount: 45 } } });
+      grid.pagination.lastPage();
+      expect(grid.pagination.page).toBe(5);
+      expect(grid.pagination.startItem).toBe(41);
+      expect(grid.pagination.endItem).toBe(45);
+    });
+  });
+
+  it('delegates page changes to the grid callback (controlled)', () => {
+    const onPageChange = vi.fn();
+    const { pagination } = getGrid({ page: 2, onPageChange });
+    pagination.nextPage();
+    expect(onPageChange).toHaveBeenCalledWith(3, 10);
+  });
+});

--- a/src/components/dataGrid/models/paginationModel.ts
+++ b/src/components/dataGrid/models/paginationModel.ts
@@ -1,0 +1,81 @@
+import { PaginationState } from '../contracts/dataGridContract';
+import GridModel from './gridModel';
+
+/**
+ * Pagination concern: navigation state + derived row range for the bottom bar / pager.
+ * The coupled mutations (page-reset on filter/sort, server-state events) live on GridModel;
+ * this model owns the navigation behavior and derivations the UI needs.
+ */
+export default class PaginationModel<TRow> {
+  constructor(public readonly grid: GridModel<TRow>) {}
+
+  public get isPaginated(): boolean {
+    return this.grid.isPaginated;
+  }
+
+  public get state(): PaginationState | undefined {
+    return this.grid.paginationState;
+  }
+
+  public get pageSizeOptions(): number[] | undefined {
+    return this.grid.pageSizeOptions;
+  }
+
+  public get page(): number {
+    return this.grid.page;
+  }
+
+  public get pageSize(): number {
+    return this.grid.pageSize;
+  }
+
+  public get totalPages(): number {
+    return this.state?.totalPages ?? 1;
+  }
+
+  public get totalItems(): number {
+    return this.state?.totalItems ?? 0;
+  }
+
+  public get canGoPrev(): boolean {
+    return this.page > 1;
+  }
+
+  public get canGoNext(): boolean {
+    return this.page < this.totalPages;
+  }
+
+  /** 1-based index of the first row on the current page. */
+  public get startItem(): number {
+    return (this.page - 1) * this.pageSize + 1;
+  }
+
+  /** 1-based index of the last row on the current page (clamped to totalItems). */
+  public get endItem(): number {
+    return Math.min(this.startItem + this.pageSize - 1, this.totalItems);
+  }
+
+  public changePage = (page: number): void => this.grid.changePage(page);
+  public changePageSize = (size: number): void => this.grid.changePageSize(size);
+
+  public firstPage = (): void => {
+    if (this.canGoPrev) this.grid.changePage(1);
+  };
+  public prevPage = (): void => {
+    if (this.canGoPrev) this.grid.changePage(this.page - 1);
+  };
+  public nextPage = (): void => {
+    if (this.canGoNext) this.grid.changePage(this.page + 1);
+  };
+  public lastPage = (): void => {
+    if (this.canGoNext) this.grid.changePage(this.totalPages);
+  };
+
+  /** Parse a raw page-jump input and navigate (clamped to [1, totalPages]); ignores non-numeric input. */
+  public jumpToPage = (raw: string): void => {
+    const n = parseInt(raw, 10);
+    if (!isNaN(n)) {
+      this.grid.changePage(Math.max(1, Math.min(n, this.totalPages)));
+    }
+  };
+}

--- a/src/components/dataGrid/models/rowModel.ts
+++ b/src/components/dataGrid/models/rowModel.ts
@@ -1,3 +1,4 @@
+import memo from '../../../utils/memo';
 import { Key } from '../contracts/dataGridContract';
 import CellModel from './cellModel';
 import DetailRowModel from './detailRowModel';
@@ -18,9 +19,22 @@ export default class RowModel<TRow> {
   public readonly key: Key;
   public parentRow?: GroupRowModel<TRow>;
   public readonly count = 1;
+  public readonly kind = 'row' as const;
 
+  /** Whether clicking the row toggles its detail panel. */
+  public get expandOnRowClick(): boolean {
+    return this.grid.props.def.rowDetail?.expandOnRowClick ?? false;
+  }
+
+  public toggleDetail = (): void => {
+    this.grid.toggleDetailRow(this.key);
+  };
+
+  // Memoized per row instance: rows are rebuilt whenever columns/data/sort/filter change,
+  // so cached cells stay valid for the row's lifetime (stops per-render allocation).
+  private readonly _cells = memo(() => this.grid.columns.value.visibleLeafs.map((c) => new CellModel<TRow>(this.grid, this, c)));
   public get cells(): CellModel<TRow>[] {
-    return this.grid.columns.value.visibleLeafs.map((c) => new CellModel<TRow>(this.grid, this, c));
+    return this._cells.value;
   }
 
   public get selected() {

--- a/src/components/dataGrid/models/viewportModel.test.ts
+++ b/src/components/dataGrid/models/viewportModel.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { ignoreLogs } from '../../../../dev/tests';
+import { GridDefinition } from '../contracts/dataGridContract';
+import GridModel from './gridModel';
+import ViewportModel from './viewportModel';
+
+interface Row {
+  id: number;
+  name: string;
+}
+
+const makeData = (n: number): Row[] => Array.from({ length: n }, (_, i) => ({ id: i + 1, name: `r${i + 1}` }));
+
+function getGrid(def?: Partial<GridDefinition<Row>>, count = 100) {
+  return new GridModel<Row>({
+    data: makeData(count),
+    def: { rowKey: 'id', columns: [{ key: 'name' }], visibleRowsCount: 10, ...def },
+  });
+}
+
+describe('ViewportModel', () => {
+  ignoreLogs();
+
+  it('isEmpty reflects the data length', () => {
+    expect(getGrid({}, 0).viewport.isEmpty).toBe(true);
+    expect(getGrid({}, 5).viewport.isEmpty).toBe(false);
+  });
+
+  describe('fixed-height windowing', () => {
+    it('at scrollTop 0: startIndex 0, take = visibleRows + 2*preload, translateY 0', () => {
+      const grid = getGrid();
+      const w = grid.viewport.window(0);
+      expect(w.startIndex).toBe(0);
+      expect(w.take).toBe(10 + ViewportModel.ROWS_TO_PRELOAD * 2);
+      expect(w.translateY).toBe(0);
+    });
+
+    it('scrolling down moves the window start back by the preload margin', () => {
+      const grid = getGrid();
+      const rowHeight = grid.rowHeight;
+      // scroll to row 50
+      const w = grid.viewport.window(rowHeight * 50);
+      expect(w.startIndex).toBe(50 - ViewportModel.ROWS_TO_PRELOAD);
+      expect(w.translateY).toBe(w.startIndex * rowHeight);
+    });
+
+    it('totalHeight = rowCount * rowHeight and viewHeight is fixed', () => {
+      const grid = getGrid();
+      expect(grid.viewport.totalHeight).toBe(grid.flatRows.value.length * grid.rowHeight);
+      expect(grid.viewport.viewHeight).toBe(grid.rowHeight * 10 + grid.rowHeight / 5);
+    });
+  });
+
+  describe('showAll', () => {
+    it('renders every row with no translate and undefined viewHeight', () => {
+      const grid = getGrid({ visibleRowsCount: 'all' }, 30);
+      expect(grid.viewport.showAll).toBe(true);
+      const w = grid.viewport.window(99999);
+      expect(w.startIndex).toBe(0);
+      expect(w.take).toBe(30);
+      expect(w.translateY).toBe(0);
+      expect(w.viewHeight).toBeUndefined();
+    });
+  });
+
+  describe('variable-height windowing (row detail)', () => {
+    it('uses the rowOffsets binary search and offset-based translateY', () => {
+      const grid = getGrid({ rowDetail: { content: () => null } }, 100);
+      // expand a row so offsets are non-uniform
+      grid.toggleDetailRow(grid.getRowKey(grid.props.data[0]));
+
+      expect(grid.viewport.hasDetailRows).toBe(true);
+      const { offsets } = grid.rowOffsets.value;
+      const target = offsets[40];
+      const w = grid.viewport.window(target);
+      // start is the found index minus preload
+      expect(w.startIndex).toBe(Math.max(0, 40 - ViewportModel.ROWS_TO_PRELOAD));
+      expect(w.translateY).toBe(offsets[w.startIndex]);
+      expect(w.totalHeight).toBe(grid.rowOffsets.value.totalHeight);
+    });
+  });
+
+  it('emptyHeight falls back to default row count when showing all', () => {
+    const grid = getGrid({ visibleRowsCount: 'all' }, 0);
+    expect(grid.viewport.emptyHeight).toBe(grid.rowHeight * ViewportModel.DEFAULT_VISIBLE_ROWS_COUNT);
+  });
+});

--- a/src/components/dataGrid/models/viewportModel.ts
+++ b/src/components/dataGrid/models/viewportModel.ts
@@ -1,0 +1,99 @@
+import GridModel from './gridModel';
+
+/** Windowing parameters for the virtualized body. Rows are sliced by the adapter from these. */
+export interface ViewportWindow {
+  /** Index of the first row to render. */
+  startIndex: number;
+  /** Number of rows to render starting at `startIndex`. */
+  take: number;
+  /** Pixel offset to translate the rendered slice down to its scroll position. */
+  translateY: number;
+  /** Total scrollable height of all rows. */
+  totalHeight: number;
+  /** Fixed viewport height, or undefined when rendering all rows. */
+  viewHeight: number | undefined;
+}
+
+/**
+ * Headless virtualization: given a scrollTop, computes which rows are visible and how
+ * to position them. Pure math — `scrollTop` is owned by the adapter (so scrolling does
+ * not notify the store / re-render the whole grid).
+ */
+export default class ViewportModel<TRow> {
+  static readonly DEFAULT_VISIBLE_ROWS_COUNT = 10;
+  static readonly ROWS_TO_PRELOAD = 20;
+
+  constructor(public readonly grid: GridModel<TRow>) {}
+
+  public get showAll(): boolean {
+    return this.grid.props.def.visibleRowsCount === 'all';
+  }
+
+  public get hasDetailRows(): boolean {
+    return !!this.grid.props.def.rowDetail;
+  }
+
+  public get isEmpty(): boolean {
+    return this.grid.props.data.length === 0;
+  }
+
+  /** Number of rows the viewport shows at once (all rows when `visibleRowsCount === 'all'`). */
+  public get visibleRowsCount(): number {
+    if (this.showAll) return this.grid.flatRows.value.length;
+    const vrc = this.grid.props.def.visibleRowsCount;
+    return typeof vrc === 'number' ? vrc : ViewportModel.DEFAULT_VISIBLE_ROWS_COUNT;
+  }
+
+  public get viewHeight(): number | undefined {
+    if (this.showAll) return undefined;
+    const { rowHeight } = this.grid;
+    return rowHeight * this.visibleRowsCount + rowHeight / 5;
+  }
+
+  public get totalHeight(): number {
+    return this.hasDetailRows ? this.grid.rowOffsets.value.totalHeight : this.grid.flatRows.value.length * this.grid.rowHeight;
+  }
+
+  /** Height to reserve for the empty/no-data state. */
+  public get emptyHeight(): number {
+    return this.viewHeight ?? this.grid.rowHeight * ViewportModel.DEFAULT_VISIBLE_ROWS_COUNT;
+  }
+
+  /** Binary search for the first row whose offset is <= scrollTop (variable-height rows). */
+  private findStartIndex(offsets: number[], scrollTop: number): number {
+    let lo = 0;
+    let hi = offsets.length - 1;
+
+    while (lo < hi) {
+      const mid = (lo + hi + 1) >>> 1;
+      if (offsets[mid] <= scrollTop) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+
+    return lo;
+  }
+
+  public window(scrollTop: number): ViewportWindow {
+    const length = this.grid.flatRows.value.length;
+
+    if (this.showAll) {
+      return { startIndex: 0, take: length, translateY: 0, totalHeight: this.totalHeight, viewHeight: undefined };
+    }
+
+    const { rowHeight } = this.grid;
+    const preload = ViewportModel.ROWS_TO_PRELOAD;
+    const { offsets } = this.grid.rowOffsets.value;
+
+    const startIndex = this.hasDetailRows
+      ? Math.max(0, this.findStartIndex(offsets, scrollTop) - preload)
+      : Math.max(0, Math.floor(scrollTop / rowHeight) - preload);
+
+    const translateY = this.hasDetailRows ? (offsets[startIndex] ?? 0) : startIndex * rowHeight;
+    const take = this.visibleRowsCount + preload * 2;
+
+    return { startIndex, take, translateY, totalHeight: this.totalHeight, viewHeight: this.viewHeight };
+  }
+}

--- a/src/components/dataGrid/useGrid.ts
+++ b/src/components/dataGrid/useGrid.ts
@@ -1,47 +1,26 @@
-import { useRef, useState } from 'react';
+import { useRef, useSyncExternalStore } from 'react';
 import { DataGridProps } from './contracts/dataGridContract';
 import GridModel from './models/gridModel';
 
+/**
+ * React binding for the headless GridModel store.
+ *
+ * The model owns all state and behavior; React only subscribes. `setProps` syncs
+ * incoming props during render (clearing affected memos lazily), and
+ * `useSyncExternalStore` re-renders this component whenever the model calls notify().
+ */
 export default function useGrid<TRow>(props: DataGridProps<TRow>): GridModel<TRow> {
-  const [_, setUpdate] = useState(0);
-
   const gridRef = useRef<GridModel<TRow>>();
   if (!gridRef.current) {
-    gridRef.current = new GridModel(props, () => setUpdate((u) => u + 1));
+    gridRef.current = new GridModel(props);
   }
 
   const grid = gridRef.current;
-  const prev = grid.props;
 
-  // Sync props during render — no useEffect needed.
-  // Memos recompute lazily when accessed, so no extra render cycle is triggered.
-  if (prev !== props) {
-    grid.props = props;
+  // Sync props during render — memos recompute lazily, so no extra render is triggered.
+  grid.setProps(props);
 
-    // Definition changed — clear everything (columns, headers, layout, rows)
-    if (prev.def !== props.def) {
-      grid.sourceColumns.clear();
-      grid.columns.clear();
-      grid.headerRows.clear();
-      grid.gridTemplateColumns.clear();
-      grid.sizes.clear();
-    }
-
-    // Clear row-related memos when any row-affecting prop changes
-    if (
-      prev.data !== props.data ||
-      prev.def !== props.def ||
-      prev.globalFilterValue !== props.globalFilterValue ||
-      prev.columnFilters !== props.columnFilters ||
-      prev.filters !== props.filters ||
-      prev.expandedRowKeys !== props.expandedRowKeys ||
-      prev.page !== props.page
-    ) {
-      grid.rows.clear();
-      grid.flatRows.clear();
-      grid.rowOffsets.clear();
-    }
-  }
+  useSyncExternalStore(grid.subscribe, grid.getSnapshot, grid.getSnapshot);
 
   return grid;
 }

--- a/src/core/boxStyles.ts
+++ b/src/core/boxStyles.ts
@@ -1285,6 +1285,21 @@ export const cssStyles = {
       styleName: 'backdrop-filter',
     },
   ],
+  scrollbarWidth: [
+    {
+      values: ['auto', 'thin', 'none'] as const,
+      styleName: 'scrollbar-width',
+    },
+  ],
+  /** The scrollbar-color CSS property sets the color of the scrollbar thumb and track. The value pair is [thumbColor, trackColor]. */
+  scrollbarColor: [
+    {
+      tuple: true,
+      values: [Variables.colorValues, Variables.colorValues] as const,
+      styleName: 'scrollbar-color',
+      valueFormat: (value, getVariableValue) => `${getVariableValue(value[0] as string)} ${getVariableValue(value[1] as string)}`,
+    },
+  ],
 } satisfies Record<string, BoxStyle[]>;
 
 export const pseudo1 = {

--- a/src/core/coreTypes.ts
+++ b/src/core/coreTypes.ts
@@ -1,3 +1,9 @@
+export type ExtractTupleValues<T> = T extends readonly unknown[]
+  ? {
+      -readonly [K in keyof T]: T[K] extends ReadonlyArray<infer U> ? U : never;
+    }
+  : never;
+
 export type BoxStylesType<T> = T extends ReadonlyArray<unknown> ? T[number] : T;
 
 export type ExtractElementType<T> =
@@ -30,7 +36,17 @@ interface BoxStyleString {
   valueFormat?: (value: string) => string;
 }
 
-export type BoxStyle = (BoxStyleArrayString | BoxStyleArrayBoolean | BoxStyleArrayNumber | BoxStyleNumber | BoxStyleString) & {
+interface BoxStyleTupleArrays {
+  tuple: true;
+  values: readonly ReadonlyArray<string | number | boolean>[];
+  valueFormat?: (value: readonly (string | number | boolean)[], getVariableValue: (name: string) => string, styleName?: string) => string;
+}
+
+type BoxStyleScalar = (BoxStyleArrayString | BoxStyleArrayBoolean | BoxStyleArrayNumber | BoxStyleNumber | BoxStyleString) & {
+  tuple?: never;
+};
+
+export type BoxStyle = (BoxStyleScalar | BoxStyleTupleArrays) & {
   styleName?: string | string[];
   selector?: (className: string, pseudoClass: string) => string;
 };

--- a/src/core/extends/boxComponents.ts
+++ b/src/core/extends/boxComponents.ts
@@ -1101,6 +1101,10 @@ const boxComponents = {
               isFirstLeaf: {},
               isLastLeaf: {},
               isEmptyCell: {},
+              isRowDetail: {},
+              isExpanded: {},
+              isExpandedFirstLeaf: {},
+              isExpandedLastLeaf: {},
             },
             children: {
               text: {
@@ -1109,6 +1113,9 @@ const boxComponents = {
               rowDetail: {
                 clean: true,
                 styles: {},
+                variants: {
+                  isExpanded: {},
+                },
               },
             },
           },
@@ -1120,6 +1127,11 @@ const boxComponents = {
                 dark: {
                   borderColor: 'gray-800',
                 },
+              },
+            },
+            children: {
+              content: {
+                styles: {},
               },
             },
           },
@@ -1185,6 +1197,9 @@ const boxComponents = {
         },
       },
     },
+  },
+  'orders-datagrid': {
+    extends: 'datagrid',
   },
 } satisfies Components;
 

--- a/src/core/extends/boxComponents.ts
+++ b/src/core/extends/boxComponents.ts
@@ -661,7 +661,9 @@ const boxComponents = {
     },
     children: {
       content: {
-        styles: {},
+        styles: {
+          scrollbarColor: ['violet-500', 'transparent'],
+        },
       },
       topBar: {
         styles: {
@@ -842,7 +844,30 @@ const boxComponents = {
             },
             children: {
               input: {
-                styles: {},
+                styles: {
+                  display: 'flex',
+                  ai: 'center',
+                  b: 1,
+                  borderColor: 'gray-200',
+                  borderRadius: 1,
+                  position: 'relative',
+                  width: 'fit',
+                  focus: {
+                    borderColor: 'indigo-500',
+                    outline: 2,
+                    outlineOffset: 0,
+                    outlineColor: 'indigo-200',
+                  },
+                  theme: {
+                    dark: {
+                      borderColor: 'gray-700',
+                      focus: {
+                        borderColor: 'indigo-400',
+                        outlineColor: 'indigo-900',
+                      },
+                    },
+                  },
+                },
               },
             },
           },

--- a/src/core/extends/boxComponents.ts
+++ b/src/core/extends/boxComponents.ts
@@ -661,9 +661,7 @@ const boxComponents = {
     },
     children: {
       content: {
-        styles: {
-          scrollbarColor: ['violet-500', 'transparent'],
-        },
+        styles: {},
       },
       topBar: {
         styles: {

--- a/src/core/theme/theme.test.tsx
+++ b/src/core/theme/theme.test.tsx
@@ -625,6 +625,52 @@ describe('Theme', () => {
     });
   });
 
+  describe('globalStyles', () => {
+    const getStyleSheet = () => document.getElementById('crono-styles') as unknown as HTMLStyleElement;
+
+    it('emits a rule targeting `html` when use="global"', () => {
+      render(
+        <Theme use="global" globalStyles={{ scrollbarColor: ['violet-500', 'transparent'] }}>
+          <Box id={testId}>Content</Box>
+        </Theme>,
+      );
+
+      expect(getStyleSheet().innerText).toContain('html{scrollbar-color:var(--violet-500) var(--transparent)}');
+    });
+
+    it('emits a compound selector `html.<theme>` for theme-keyed values', () => {
+      render(
+        <Theme theme="dark" use="global" globalStyles={{ theme: { dark: { scrollbarColor: ['violet-700', 'gray-900'] } } }}>
+          <Box id={testId}>Content</Box>
+        </Theme>,
+      );
+
+      expect(getStyleSheet().innerText).toContain('html.dark{scrollbar-color:var(--violet-700) var(--gray-900)}');
+    });
+
+    it('does NOT emit an `html` rule when use="local"', () => {
+      render(
+        <Theme use="local" globalStyles={{ scrollbarColor: ['fuchsia-500', 'transparent'] }}>
+          <Box id={testId}>Content</Box>
+        </Theme>,
+      );
+
+      expect(getStyleSheet().innerText).not.toContain('html{scrollbar-color:var(--fuchsia-500)');
+    });
+
+    it('emits multiple global props in a single Theme', () => {
+      render(
+        <Theme use="global" globalStyles={{ scrollbarColor: ['emerald-500', 'transparent'], scrollbarWidth: 'thin' }}>
+          <Box id={testId}>Content</Box>
+        </Theme>,
+      );
+
+      const sheet = getStyleSheet().innerText;
+      expect(sheet).toContain('html{scrollbar-color:var(--emerald-500) var(--transparent)}');
+      expect(sheet).toContain('html{scrollbar-width:thin}');
+    });
+  });
+
   describe('localStorage persistence', () => {
     const storageKey = 'test-theme';
 

--- a/src/core/theme/theme.tsx
+++ b/src/core/theme/theme.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useContext, useLayoutEffect, useRef, useState } from 'react';
 import Box from '../../box';
+import { BoxStyleProps } from '../../types';
+import { useGlobalStyles } from '../useStyles';
 import ThemeContext from './themeContext';
 
 interface ThemeProps {
@@ -8,10 +10,18 @@ interface ThemeProps {
   use?: 'global' | 'local';
   /** When provided, persists the user-selected theme to localStorage under this key. */
   storageKey?: string;
+  /**
+   * App-wide Box style props applied to the document root (`<html>`). Only takes effect when `use="global"`.
+   * Supports the same shape as Box props, including theme-keyed values:
+   * `globalStyles={{ scrollbarColor: ['violet-500', 'transparent'], theme: { dark: { scrollbarColor: [...] } } }}`.
+   */
+  globalStyles?: BoxStyleProps;
 }
 
 function Theme(props: ThemeProps) {
-  const { children, theme, use = 'local', storageKey } = props;
+  const { children, theme, use = 'local', storageKey, globalStyles } = props;
+
+  useGlobalStyles(use === 'global' ? globalStyles : undefined, 'html');
   // Initialize with 'light' for SSR consistency - actual system theme is set in useLayoutEffect
   const [themeName, setThemeName] = useState(theme ?? 'light');
   const [isUserOverride, setIsUserOverride] = useState(theme !== undefined);

--- a/src/core/useStyles.ts
+++ b/src/core/useStyles.ts
@@ -73,13 +73,13 @@ namespace StylesContextImpl {
       // key = weight of pseudo classes
       [key: number]: {
         // key = css style (box props)
-        [key: string]: Set<string | number | boolean>;
+        [key: string]: Set<string | number | boolean | readonly (string | number | boolean)[]>;
       } & {
         __parents?: {
           // key = parent name
           [key: string]: {
             // key = css style (box props)
-            [key: string]: Set<string | number | boolean>;
+            [key: string]: Set<string | number | boolean | readonly (string | number | boolean)[]>;
           };
         };
       };
@@ -241,7 +241,7 @@ namespace StylesContextImpl {
 
   function generateRule(
     key: string,
-    value: string | number | boolean,
+    value: string | number | boolean | readonly (string | number | boolean)[],
     weight: number,
     breakpoint: string,
     pseudoClassParentName?: string,
@@ -250,6 +250,13 @@ namespace StylesContextImpl {
 
     const itemValue = item.find((x) => {
       if (Array.isArray(x.values)) {
+        if (Array.isArray(value)) {
+          // Tuple definition: x.values is a tuple of allowed-value arrays; each position must contain value[i]
+          if (x.values.length > 0 && Array.isArray(x.values[0])) {
+            return x.values.length === value.length && (x.values as unknown[][]).every((allowed, i) => allowed.includes(value[i]));
+          }
+          return x.values.length === value.length && x.values.every((v, i) => typeof v === typeof value[i]);
+        }
         return x.values.includes(value);
       }
       return typeof value === typeof x.values;
@@ -349,13 +356,20 @@ namespace StylesContextImpl {
     const className = createClassName(key, value, weight, breakpoint, pseudoClassParentName);
 
     // Create a unique key to track if this rule has been generated
-    const ruleKey = `${breakpoint}-${weight}-${key}-${value}-${pseudoClassParentName ?? ''}`;
+    const serializedValue = Array.isArray(value) ? value.join('_') : value;
+    const ruleKey = `${breakpoint}-${weight}-${key}-${serializedValue}-${pseudoClassParentName ?? ''}`;
 
     // Only generate rule if it hasn't been generated before
     if (!generatedRules.has(ruleKey)) {
       generatedRules.add(ruleKey);
 
-      const result = generateRule(key, value as string | number | boolean, weight, breakpoint, pseudoClassParentName);
+      const result = generateRule(
+        key,
+        value as string | number | boolean | readonly (string | number | boolean)[],
+        weight,
+        breakpoint,
+        pseudoClassParentName,
+      );
       if (result) {
         pendingRules.push([result.sortIndex, result.breakpointOrder, result.rule]);
         requireFlush = true;
@@ -395,8 +409,9 @@ namespace StylesContextImpl {
     pseudoClassParentName?: string,
   ) {
     const pseudoClasses = pseudoClassesByWeight[weight];
+    const serializedValue = Array.isArray(value) ? value.join('_') : value;
 
-    const className = `${breakpoint === 'normal' ? '' : `${breakpoint}-`}${pseudoClasses.map((p) => `${p}-`).join('')}${pseudoClassParentName ? `${pseudoClassParentName}-` : ''}${key}-${value}`;
+    const className = `${breakpoint === 'normal' ? '' : `${breakpoint}-`}${pseudoClasses.map((p) => `${p}-`).join('')}${pseudoClassParentName ? `${pseudoClassParentName}-` : ''}${key}-${serializedValue}`;
 
     return isTestEnv ? className : identity.getIdentity(className);
   }

--- a/src/core/useStyles.ts
+++ b/src/core/useStyles.ts
@@ -48,6 +48,17 @@ export default function useStyles(props: BoxStyleProps<any>, isSvg: boolean) {
   return classNames;
 }
 
+export function useGlobalStyles(props: BoxStyleProps<any> | undefined, selector: string) {
+  if (props) {
+    const throwawayClassNames: string[] = [];
+    StylesContextImpl.addClassNames(props, throwawayClassNames, [], undefined, undefined, selector);
+  }
+
+  useEff(() => {
+    StylesContextImpl.flush();
+  }, [props, selector]);
+}
+
 namespace StylesContextImpl {
   let requireFlush = true;
   let isInitialized = false;
@@ -92,26 +103,41 @@ namespace StylesContextImpl {
     currentPseudoClasses: PseudoClassesType[],
     breakpoint?: string,
     pseudoClassParentName?: string,
+    rootSelector?: string,
   ) {
     Object.entries(props).forEach(([key, value]) => {
       if (value === undefined || value === null) return;
       if (ObjectUtils.isKeyOf(key, cssStyles)) {
-        addClassName(key, value, classNames, currentPseudoClasses, breakpoint, pseudoClassParentName);
+        addClassName(key, value, classNames, currentPseudoClasses, breakpoint, pseudoClassParentName, rootSelector);
       } else if (ObjectUtils.isKeyOf(key, pseudo1)) {
-        addClassNames(value as BoxStyleProps, classNames, [...currentPseudoClasses, key], breakpoint, pseudoClassParentName);
+        addClassNames(value as BoxStyleProps, classNames, [...currentPseudoClasses, key], breakpoint, pseudoClassParentName, rootSelector);
       } else if (ObjectUtils.isKeyOf(key, pseudo2)) {
         if (Array.isArray(value)) {
           const [_, styles] = value as [unknown, BoxStyleProps];
-          addClassNames(styles, classNames, [...currentPseudoClasses, key], breakpoint, pseudoClassParentName);
+          addClassNames(styles, classNames, [...currentPseudoClasses, key], breakpoint, pseudoClassParentName, rootSelector);
         }
         if (ObjectUtils.isObject(value)) {
-          addClassNames(value as BoxStyleProps, classNames, [...currentPseudoClasses, key], breakpoint, pseudoClassParentName);
+          addClassNames(
+            value as BoxStyleProps,
+            classNames,
+            [...currentPseudoClasses, key],
+            breakpoint,
+            pseudoClassParentName,
+            rootSelector,
+          );
         }
       } else if (ObjectUtils.isKeyOf(key, breakpoints)) {
-        addClassNames(value as BoxStyleProps, classNames, currentPseudoClasses, key, pseudoClassParentName);
+        addClassNames(value as BoxStyleProps, classNames, currentPseudoClasses, key, pseudoClassParentName, rootSelector);
       } else if (ObjectUtils.isKeyOf(key, pseudoGroupClasses)) {
         Object.entries(value).forEach(([name, pseudoClassProps]) => {
-          addClassNames(pseudoClassProps as BoxStyles, classNames, [...currentPseudoClasses, pseudoGroupClasses[key]], breakpoint, name);
+          addClassNames(
+            pseudoClassProps as BoxStyles,
+            classNames,
+            [...currentPseudoClasses, pseudoGroupClasses[key]],
+            breakpoint,
+            name,
+            rootSelector,
+          );
         });
       } else if (ObjectUtils.isKeyOf(key, themeGroupClass)) {
         Object.entries(value).forEach(([name, themeProps]) => {
@@ -127,10 +153,11 @@ namespace StylesContextImpl {
                   breakpoint,
                   // Use | as separator to distinguish theme from group name
                   `${name}|${groupName}`,
+                  rootSelector,
                 );
               });
             } else {
-              addClassNames({ [themeKey]: themeValue } as BoxStyles, classNames, themePseudoClasses, breakpoint, name);
+              addClassNames({ [themeKey]: themeValue } as BoxStyles, classNames, themePseudoClasses, breakpoint, name, rootSelector);
             }
           });
         });
@@ -245,6 +272,7 @@ namespace StylesContextImpl {
     weight: number,
     breakpoint: string,
     pseudoClassParentName?: string,
+    rootSelector?: string,
   ): { rule: string; sortIndex: number; breakpointOrder: number } | null {
     const item = cssStyles[key as keyof typeof cssStyles] as BoxStyle[];
 
@@ -285,7 +313,17 @@ namespace StylesContextImpl {
       const hasThemeAndGroup = pseudoClassParentName.includes('|');
       let defaultSelector: string;
 
-      if (hasThemeAndGroup) {
+      if (rootSelector) {
+        // Global mode: rules target the root selector (e.g. `html`) directly.
+        // Group selectors are not meaningful for the document root — skip them.
+        if (hasThemeAndGroup) return null;
+        if (hasTheme) {
+          // Theme on same element as rootSelector → compound selector
+          defaultSelector = `${rootSelector}.${pseudoClassParentName}${pseudoClassesToUse}`;
+        } else {
+          return null;
+        }
+      } else if (hasThemeAndGroup) {
         // Combined theme + group: .themeName .groupName:hover .className
         const [themeName, groupName] = pseudoClassParentName.split('|');
         defaultSelector = `.${themeName} .${groupName}${pseudoClassesToUse} .${className}`;
@@ -314,7 +352,8 @@ namespace StylesContextImpl {
       return { rule, sortIndex, breakpointOrder };
     } else {
       const pseudoClassesToUse = pseudoClassesByWeight[weight].map((p) => pseudoClasses[p]).join('');
-      const selector = itemValue.selector?.(`.${className}`, pseudoClassesToUse) ?? `.${className}${pseudoClassesToUse}`;
+      const baseSelector = rootSelector ?? `.${className}`;
+      const selector = itemValue.selector?.(baseSelector, pseudoClassesToUse) ?? `${baseSelector}${pseudoClassesToUse}`;
 
       const styleName = Array.isArray(itemValue.styleName) ? itemValue.styleName : [itemValue.styleName ?? key];
 
@@ -349,6 +388,7 @@ namespace StylesContextImpl {
     currentPseudoClasses: PseudoClassesType[],
     breakpoint: string = 'normal',
     pseudoClassParentName?: string,
+    rootSelector?: string,
   ) {
     if (value === undefined || value === null) return;
 
@@ -357,7 +397,7 @@ namespace StylesContextImpl {
 
     // Create a unique key to track if this rule has been generated
     const serializedValue = Array.isArray(value) ? value.join('_') : value;
-    const ruleKey = `${breakpoint}-${weight}-${key}-${serializedValue}-${pseudoClassParentName ?? ''}`;
+    const ruleKey = `${breakpoint}-${weight}-${key}-${serializedValue}-${pseudoClassParentName ?? ''}-${rootSelector ?? ''}`;
 
     // Only generate rule if it hasn't been generated before
     if (!generatedRules.has(ruleKey)) {
@@ -369,6 +409,7 @@ namespace StylesContextImpl {
         weight,
         breakpoint,
         pseudoClassParentName,
+        rootSelector,
       );
       if (result) {
         pendingRules.push([result.sortIndex, result.breakpointOrder, result.rule]);

--- a/src/hooks/useVisibility.ts
+++ b/src/hooks/useVisibility.ts
@@ -19,7 +19,7 @@ export default function useVisibility<T extends HTMLElement = HTMLDivElement>(
   useEffect(() => {
     function clickHandler(e: MouseEvent) {
       const el = node ?? visibilityRef.current;
-      const shouldHide = el?.contains(e.target as Node) === false;
+      const shouldHide = el ? !e.composedPath().includes(el) : false;
 
       if (shouldHide) {
         setVisibility(false);
@@ -32,7 +32,7 @@ export default function useVisibility<T extends HTMLElement = HTMLDivElement>(
 
     function scrollHandler(e: Event) {
       const el = node ?? visibilityRef.current;
-      const shouldHide = el?.contains(e.target as Node) === false;
+      const shouldHide = el ? !e.composedPath().includes(el) : false;
 
       if (shouldHide) {
         setVisibility(false);

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export * from './array';
 
 import { breakpoints, cssStyles, pseudo1, pseudo2, pseudoClasses, pseudoGroupClasses, themeGroupClass } from './core/boxStyles';
 import { ClassNameType } from './core/classNames';
-import { BoxStyle, BoxStylesType, ExtractKeys } from './core/coreTypes';
+import { BoxStyle, BoxStylesType, ExtractKeys, ExtractTupleValues } from './core/coreTypes';
 import boxComponents from './core/extends/boxComponents';
 
 export type ArrayType<T> = T extends (infer U)[] ? U : T;
@@ -14,13 +14,19 @@ export namespace Augmented {
   export interface ComponentsTypes {}
 }
 
+type ExtractBoxStyleValue<T> = T extends { tuple: true; values: infer V }
+  ? ExtractTupleValues<V>
+  : T extends { values: infer V }
+    ? BoxStylesType<V>
+    : never;
+
 type ExtractBoxStylesInternal<T extends Record<string, BoxStyle[]>> = {
   [K in keyof T]?: K extends keyof Augmented.BoxPropTypes
-    ? BoxStylesType<ArrayType<T[K]>['values']> | Augmented.BoxPropTypes[K]
-    : BoxStylesType<ArrayType<T[K]>['values']>;
+    ? ExtractBoxStyleValue<ArrayType<T[K]>> | Augmented.BoxPropTypes[K]
+    : ExtractBoxStyleValue<ArrayType<T[K]>>;
 };
 export type ExtractBoxStyles<T extends Record<string, BoxStyle[]>> = {
-  [K in keyof T]?: BoxStylesType<ArrayType<T[K]>['values']>;
+  [K in keyof T]?: ExtractBoxStyleValue<ArrayType<T[K]>>;
 };
 
 export type PseudoClassesType = keyof typeof pseudoClasses;
@@ -98,3 +104,5 @@ export type BoxStyleProps<TKey extends keyof ComponentsAndVariants = never> = Si
 export type BoxComponentStyles = Simplify<
   BoxStylesWithPseudoClasses & BoxBreakpointsStyles & BoxPseudoGroupClassesStyles & BoxThemeGroupClassStyles
 >;
+
+type Test = ExtractBoxStylesInternal<typeof cssStyles>;

--- a/src/utils/memo.test.ts
+++ b/src/utils/memo.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import memo, { Memo } from './memo';
+
+describe('memo', () => {
+  it('computes lazily and caches the result', () => {
+    const fn = vi.fn(() => 42);
+    const m = memo(fn);
+
+    expect(fn).not.toHaveBeenCalled(); // lazy
+    expect(m.value).toBe(42);
+    expect(m.value).toBe(42);
+    expect(fn).toHaveBeenCalledTimes(1); // cached
+  });
+
+  it('recomputes after clear()', () => {
+    let n = 0;
+    const m = memo(() => ++n);
+
+    expect(m.value).toBe(1);
+    m.clear();
+    expect(m.value).toBe(2);
+  });
+
+  it('caches an undefined result (sentinel, not value-based)', () => {
+    const fn = vi.fn(() => undefined);
+    const m = memo(fn);
+
+    expect(m.value).toBeUndefined();
+    expect(m.value).toBeUndefined();
+    expect(fn).toHaveBeenCalledTimes(1); // would be 2 with the old `cache === undefined` bug
+  });
+
+  describe('dependency cascade', () => {
+    it('clearing a dependency cascades to dependents', () => {
+      let a = 0;
+      const root = memo(() => ++a);
+      const childFn = vi.fn(() => root.value * 10);
+      const child = memo(childFn, () => [root]);
+
+      expect(child.value).toBe(10); // root=1
+      expect(child.value).toBe(10); // cached
+      expect(childFn).toHaveBeenCalledTimes(1);
+
+      root.clear(); // cascades to child
+      expect(child.value).toBe(20); // root recomputed to 2
+      expect(childFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('cascades through a multi-level chain', () => {
+      let a = 0;
+      const root = memo(() => ++a);
+      const mid = memo(
+        () => root.value,
+        () => [root],
+      );
+      const leaf = memo(
+        () => mid.value,
+        () => [mid],
+      );
+
+      expect(leaf.value).toBe(1);
+      root.clear(); // root → mid → leaf
+      expect(leaf.value).toBe(2);
+    });
+
+    it('clearing an already-cleared node does not recompute dependents (stops cascade)', () => {
+      const root = memo(() => 1);
+      const childFn = vi.fn(() => root.value);
+      const child = memo(childFn, () => [root]);
+
+      expect(child.value).toBe(1); // prime
+      expect(childFn).toHaveBeenCalledTimes(1);
+
+      root.clear(); // root was cached → cascades, clears child
+      root.clear(); // root now UNSET → early return, no further cascade
+      expect(childFn).toHaveBeenCalledTimes(1); // child not recomputed until read
+    });
+
+    it('supports a diamond (dependent of two deps) without double-recompute', () => {
+      const left = memo(() => 1);
+      const right = memo(() => 2);
+      const sinkFn = vi.fn(() => left.value + right.value);
+      const sink = memo(sinkFn, () => [left, right]);
+
+      expect(sink.value).toBe(3);
+      left.clear();
+      expect(sink.value).toBe(3);
+      expect(sinkFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('wires lazily so declaration order does not matter', () => {
+      // `dependent` is created before `root` exists; the dep thunk resolves lazily on first use.
+      const refs: { root: Memo<number> | null } = { root: null };
+      const dependent = memo(
+        () => (refs.root?.value ?? 0) + 1,
+        () => (refs.root ? [refs.root] : []),
+      );
+      refs.root = memo(() => 10);
+
+      expect(dependent.value).toBe(11);
+      refs.root.clear();
+      // re-reading dependent must reflect the cleared root
+      expect(dependent.value).toBe(11);
+    });
+  });
+});

--- a/src/utils/memo.ts
+++ b/src/utils/memo.ts
@@ -3,22 +3,60 @@ export interface Memo<T> {
   clear(): void;
 }
 
-export default function memo<T>(action: () => T): Memo<T> {
-  let cache: T | undefined;
+/** Sentinel for "not computed yet" so that a legitimately `undefined` result still caches. */
+const UNSET = Symbol('memo.unset');
 
-  const obj = {
-    clear() {
-      cache = undefined;
-    },
-  } as Memo<T>;
+class MemoNode<T> implements Memo<T> {
+  private cache: T | typeof UNSET = UNSET;
+  private readonly dependents = new Set<MemoNode<unknown>>();
+  private wired = false;
 
-  return Object.defineProperty(obj, 'value', {
-    get: () => {
-      if (cache === undefined) {
-        cache = action();
-      }
+  constructor(
+    private readonly action: () => T,
+    private readonly deps: () => Memo<unknown>[],
+  ) {}
 
-      return cache;
-    },
-  });
+  /**
+   * Register this node as a dependent of each upstream dep so that clearing a dep
+   * cascades down to this node. Done lazily on first access so class-field
+   * declaration order never matters.
+   */
+  private wire(): void {
+    if (this.wired) return;
+    this.wired = true;
+    for (const dep of this.deps() as MemoNode<unknown>[]) {
+      dep.dependents.add(this as MemoNode<unknown>);
+    }
+  }
+
+  get value(): T {
+    this.wire();
+    if (this.cache === UNSET) {
+      this.cache = this.action();
+    }
+    return this.cache as T;
+  }
+
+  clear(): void {
+    this.wire();
+    // Invariant: a cached node implies its ancestors are cached (reading a node
+    // forces its deps to compute). So if this node is already UNSET, every
+    // dependent is UNSET too — nothing to cascade. This also guards against cycles.
+    if (this.cache === UNSET) return;
+    this.cache = UNSET;
+    for (const dependent of this.dependents) {
+      dependent.clear();
+    }
+  }
+}
+
+/**
+ * Lazily-computed cached value with explicit dependency edges.
+ *
+ * Pass upstream memos via `deps` (a thunk, so it can reference sibling fields
+ * regardless of declaration order). Clearing any dep cascades to this memo, so
+ * mutations only need to clear the single root that changed.
+ */
+export default function memo<T>(action: () => T, deps: () => Memo<unknown>[] = () => []): Memo<T> {
+  return new MemoNode(action, deps);
 }


### PR DESCRIPTION
## Summary

Three coordinated changes to DataGrid and the theme system.

### 1. DataGrid features (`0af6d92`)

- **Row detail + grouping**: new `isExpanded` / `isExpandedFirstLeaf` / `isExpandedLastLeaf` variants on `body.cell` so the expanded row and its detail row can visually join (e.g. shared border). New `detailRow.content` child component lets left/right borders apply to the inner sticky box without causing horizontal scroll overflow.
- **Positional renaming**: `isFirstInRow` / `isLastInRow` replace `isFirstLeaf` / `isLastLeaf` for expanded-leaf variants (`isFirstLeaf` is always `true` for flat/non-grouped columns, so the old name was misleading).
- **Pagination page jump**: the static `"X of Y"` label is now a number input — users can jump to any page directly instead of stepping one at a time.
- **Demo**: `PaginatedDataGridDemo` updated to demonstrate filterable columns (text / number / multiselect) and `globalFilter` with full server-state handling via `onServerStateChange`. Row detail code example documents the `Box.components()` grouping setup.

### 2. DataGrid headless refactor (`f763e13`)

`GridModel` is now framework-agnostic (`subscribe` / `getSnapshot` / `notify`, bound to React via `useSyncExternalStore`) and split into specialized sub-models:

- `PaginationModel`, `ViewportModel`, `ColumnVisibilityModel`, `HeaderCellModel`, `FilterModel`

The `memo` utility was rewritten with explicit dependency edges — clearing a root memo now cascades to its dependents automatically, so invalidation is correct without manual bookkeeping. An ESLint rule enforces that the `models/` layer stays free of React/DOM imports.

New Box props: `scrollbarWidth`, `scrollbarColor`.

### 3. `Box.Theme` `globalStyles` (`e3f376b`)

New `globalStyles` prop on `Box.Theme` applies Box style props directly to the document root (`<html>`), enabling app-wide inheritable CSS like `scrollbarColor` for the page scrollbar. Supports theme-keyed values via compound `html.<theme>` selectors.

## Test plan

- [ ] `npm run compile` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (new tests: `memo`, `paginationModel`, `viewportModel`, `headerCellModel`, `columnVisibilityModel`, `columnModel.kind`, `columnModel.resize`, `gridModel.store`, `dataGrid.interaction`, theme `globalStyles`)
- [ ] `npm run build` succeeds
- [ ] Demo: row detail expansion shows joined borders across grouped columns
- [ ] Demo: pagination page-jump input navigates correctly and clamps out-of-range values
- [ ] Demo: server-side filtering (text / number / multiselect) + global filter work via `onServerStateChange`
- [ ] Demo: `Box.Theme globalStyles` applies `scrollbarColor` to the root scrollbar and updates on theme switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)