### PR TITLE
Release trust: SUPPORT/SECURITY policies and issue/PR templates (D8)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Something renders wrong, throws, or behaves unexpectedly
+title: '[bug]: '
+labels: ['bug']
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead? A screenshot of wrong rendering helps a lot.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: A minimal snippet or a link to a sandbox (StackBlitz/CodeSandbox) that shows the problem.
+      placeholder: |
+        <Box p={4} hover={{ bgColor: 'gray-100' }}>...</Box>
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: react-box version
+      placeholder: e.g. 3.3.3
+    validations:
+      required: true
+  - type: input
+    id: react-version
+    attributes:
+      label: React version
+      placeholder: e.g. 19.2.8
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Bundler/framework and rendering mode if relevant.
+      placeholder: e.g. Vite 8 SPA / Next.js 15 App Router / SSG

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/cronocodesolutions/react-box/security/advisories/new
+    about: Please report security issues privately, not as public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: A new prop, component, or capability
+title: '[feature]: '
+labels: ['enhancement']
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case first — the CSS you can't express, the component you keep rebuilding, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API
+      description: What would using it look like?
+      placeholder: |
+        <Box animation="fade-in" ... />
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Workarounds you use today

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## What & why
+
+<!-- What does this PR change, and what problem does it solve? Link the issue if one exists. -->
+
+## Checklist
+
+- [ ] `npm run compile` passes
+- [ ] `npm run lint` passes
+- [ ] `npm test` passes (new behavior has tests)
+- [ ] `npm run build` passes
+- [ ] No inline `style={{ }}` — Box props only (see `.claude/rules/react-box-rules.md`)
+- [ ] Breaking change? Called out in the description with a migration note.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 **/.DS_Store
+.claude/plans

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are applied to the latest minor of the current major version.
+
+| Version | Supported |
+| ------- | --------- |
+| 3.x     | ✅        |
+| < 3.0   | ❌        |
+
+## Reporting a vulnerability
+
+Please **do not open a public issue** for security problems.
+
+Use GitHub's private vulnerability reporting: [Report a vulnerability](https://github.com/cronocodesolutions/react-box/security/advisories/new). You should receive an acknowledgement within 7 days.
+
+Once a fix is available we will publish a patched release and credit the reporter in the release notes (unless you prefer to stay anonymous).
+
+## Scope notes
+
+react-box is a styling library that injects CSS at runtime. Reports we consider in scope include (but are not limited to):
+
+- CSS injection through prop values (e.g. a crafted prop value escaping a generated rule)
+- Prototype pollution or global-scope mutation reachable from the published entries
+- Supply-chain issues in the published artifact (unexpected files, scripts, or dependencies)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,35 @@
+# Support & Stewardship
+
+## Versioning
+
+`@cronocode/react-box` follows [Semantic Versioning](https://semver.org/):
+
+- **Patch** (`3.3.x`) — bug fixes, docs, internal refactors. Always safe to upgrade.
+- **Minor** (`3.x.0`) — new props, new components, new APIs. Backwards compatible.
+- **Major** (`x.0.0`) — breaking changes only. Every breaking change ships with a written migration note in the release, and deprecated APIs keep working (with a warning) for at least one minor release before removal wherever technically possible.
+
+Breaking changes are batched: we would rather ship one well-documented major than trickle breakage across minors.
+
+## Release cadence
+
+We aim for **at least one release every month**. Every release has generated notes on the [GitHub Releases page](https://github.com/cronocodesolutions/react-box/releases).
+
+## Supported environments
+
+- **React** 16.14 – 19 (see `peerDependencies` for the authoritative range)
+- **TypeScript**: current and previous major, `moduleResolution: bundler` or `node10`. (`node16`/`nodenext` type resolution has known gaps that are on the roadmap.)
+- ESM and CJS builds are both published.
+
+## Getting help
+
+- **Bug reports & feature requests** — [GitHub issues](https://github.com/cronocodesolutions/react-box/issues). Please use the templates.
+- **Questions** — [GitHub discussions](https://github.com/cronocodesolutions/react-box/discussions) if enabled, otherwise open an issue with the question label.
+- **Security issues** — see [SECURITY.md](SECURITY.md). Please do not open public issues for vulnerabilities.
+
+## Continuity ("bus factor")
+
+A fair question for any small library. The floor is covered regardless of the maintainer:
+
+- The license is **MIT** — forking is always an option.
+- The build is fully reproducible from this repository with `npm ci && npm run build` — no private infrastructure, secrets, or services are involved in producing the published artifact.
+- Publishing runs from CI on GitHub Releases, so the release process itself is public and auditable.


### PR DESCRIPTION
Third roadmap PR (step D8, wave 1 — release trust). Independent of the other open PRs; docs/templates only, no code changes.

- **SUPPORT.md** — SemVer policy (patch/minor/major semantics, batched breaking changes with migration notes), monthly release cadence target, supported React/TS environments (honest note about the node16 types gap), and a bus-factor statement (MIT + fully reproducible public build).
- **SECURITY.md** — private vulnerability reporting via GitHub security advisories, supported versions table, scope notes (CSS injection via prop values, prototype pollution, supply chain).
- **Issue templates** — bug report and feature request as GitHub issue forms (version/reproduction fields), with a contact link steering security reports to the private channel.
- **PR template** — the four verification commands from CLAUDE.md plus the no-inline-style rule as a checklist.

Two D8 items are process rather than code and are not in this PR: the public roadmap project (needs a GitHub Projects board) and the "three consecutive monthly releases" acceptance criterion (only time can ship that one).

Note: GitHub private vulnerability reporting must be enabled once in repo Settings → Security → "Private vulnerability reporting" for the advisory link to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)